### PR TITLE
HF dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ export REMYXAI_API_KEY=<your-key-here>
 ```
 
 ## Usage
-Currently, the classify engine API is supported. Additional functionality for model management and user data is available.
+Quickly get started with the following examples:
 
 ### Model
 List all models:

--- a/README.md
+++ b/README.md
@@ -75,14 +75,42 @@ Train an image classifier:
 ```bash
 $ remyxai classify --model_name=<your-model-name> --labels="comma,separated,labels" --model_size=<int between 1-5>
 ```
+
+add the optional `--hf_dataset` if you want to train with your own image dataset on 🤗. [See the docs](https://huggingface.co/docs/datasets/v2.14.5/image_dataset#imagefolder) for more details
+
 * python command:
 ```python
 from remyxai.api import train_classifier
 
 model_name = "<your-model-name>"
 labels = ["comma", "separated", "labels"]
-model_size = 1
-print(train_classifier(model_name, labels, model_size))
+model_size = 3 # use 1 for microcontrollers
+
+# Optional HF dataset
+hf_dataset = "your/hf-dataset"
+
+print(train_classifier(model_name, labels, model_size, hf_dataset))
+```
+
+Train an object detector:
+* cli command:
+```bash
+$ remyxai detect --model_name=<your-model-name> --labels="comma,separated,labels" --model_size=<int between 1-5>
+```
+
+add the optional `--hf_dataset` if you want to train with your own image dataset on 🤗. [See the docs](https://huggingface.co/docs/datasets/v2.14.5/image_dataset#object-detection) for more details
+
+* python command:
+```python
+from remyxai.api import train_detector
+
+model_name = "<your-model-name>"
+labels = ["comma", "separated", "labels"]
+model_size = 3
+
+# Optional HF dataset
+hf_dataset = "your/hf-dataset"
+print(train_detector(model_name, labels, model_size, hf_dataset))
 ```
 
 ### User

--- a/remyxai/api.py
+++ b/remyxai/api.py
@@ -36,13 +36,22 @@ def download_model(model_name: str, model_format: str):
     return f"The file {model_name}.zip was saved successfully"
 
 # Engines
-def train_classifier(model_name: str, labels: list, model_selector: str):
+def train_classifier(model_name: str, labels: list, model_selector: str, hf_dataset=None):
     url = f"{BASE_URL}task/classify/{model_name}/{','.join(labels)}/{model_selector}"
+    if hf_dataset:
+         params = {"hf_dataset": hf_dataset}
+         response = requests.post(url, headers=HEADERS, params=params)
+         return response.json()
+
     response = requests.post(url, headers=HEADERS)
     return response.json()
 
-def train_detector(model_name: str, labels: list, model_selector: str):
+def train_detector(model_name: str, labels: list, model_selector: str, hf_dataset=None):
     url = f"{BASE_URL}task/detect/{model_name}/{','.join(labels)}/{model_selector}"
+    if hf_dataset:
+         params = {"hf_dataset": hf_dataset}
+         response = requests.post(url, headers=HEADERS, params=params)
+         return response.json()
     response = requests.post(url, headers=HEADERS)
     return response.json()
 

--- a/remyxai/cli.py
+++ b/remyxai/cli.py
@@ -36,6 +36,14 @@ def main():
     classify_parser.add_argument("--model_name", required=True, help="Name of the model")
     classify_parser.add_argument("--labels", required=True, help="Comma separated list of labels, e.g. 'cat,dog'")
     classify_parser.add_argument("--model_size", required=True, help="Integer value for model size from 1=small up to 5=large")
+    classify_parser.add_argument("--hf_dataset", required=False, default=None, help="(Optional) Name of the HuggingFace dataset to use for training")
+
+    # Define 'detect' action
+    detect_parser = subparsers_action.add_parser("detect", help="Detector-related actions")
+    detect_parser.add_argument("--model_name", required=True, help="Name of the model")
+    detect_parser.add_argument("--labels", required=True, help="Comma separated list of labels, e.g. 'cat,dog'")
+    detect_parser.add_argument("--model_size", required=True, help="Integer value for model size from 1=small up to 5=large")
+    detect_parser.add_argument("--hf_dataset", required=False, default=None, help="(Optional) Name of the HuggingFace dataset to use for training")
 
     # Define 'user' action
     user_parser = subparsers_action.add_parser("user", help="User-related actions")
@@ -74,11 +82,19 @@ def main():
             print(downloaded_model)
         else:
             print("Invalid argument for 'model'")
+
     elif args.action == "classify":
         labels = args.labels.split(",")
         labels = [x.strip() for x in labels]
-        training_classifier = train_classifier(args.model_name, labels, args.model_size)
+        training_classifier = train_classifier(args.model_name, labels, args.model_size, args.hf_dataset)
         pprint(training_classifier) 
+
+    elif args.action == "detect":                                                                            
+        labels = args.labels.split(",")
+        labels = [x.strip() for x in labels]
+        training_detector = train_detector(args.model_name, labels, args.model_size, args.hf_dataset)
+        pprint(training_detector)
+
     elif args.action == "user":
         if args.subaction == "profile":
             profile = get_user_profile()
@@ -88,6 +104,7 @@ def main():
             pprint(user_credits)
         else:
             print("Invalid argument for 'user'")
+
     elif args.action == "utils":
         if args.subaction == "label":
             labels = args.labels.split(",")
@@ -96,6 +113,7 @@ def main():
             print(results)
         else:
             print("Invalid argument for 'utils'")
+
     else:
         print("Invalid action")
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="remyxai",
-    version="0.1.3",
+    version="0.1.4",
     packages=find_packages(),
     install_requires=[
         "numpy",


### PR DESCRIPTION
Adding Huggingface datasets support 

This will allow users to use the cli/api to train a classifier or detector using a dataset hosted on Huggingface.

Classifier datasets should follow the convention described [here](https://huggingface.co/docs/datasets/v2.14.5/image_dataset#create-an-image-dataset)
Detection dataset should follow the convention described [here](https://huggingface.co/docs/datasets/v2.14.5/image_dataset#object-detection)