### PR TITLE
Add benchmark eval task

### DIFF
--- a/remyxai/api/evaluations.py
+++ b/remyxai/api/evaluations.py
@@ -1,12 +1,68 @@
 import logging
 import requests
+from typing import List
 from enum import Enum
 from . import BASE_URL, HEADERS
 
 
-# Define the EvaluationTask enum
+class EvaluationSupportedModels(Enum):
+    PHI_3_MINI_4K_INSTRUCT = "microsoft/Phi-3-mini-4k-instruct"
+    BIOMISTRAL_7B = "BioMistral/BioMistral-7B"
+    CODELLAMA_7B_INSTRUCT_HF = "codellama/CodeLlama-7b-Instruct-hf"
+    GORILLA_OPENFUNCTIONS_V2 = "gorilla-llm/gorilla-openfunctions-v2"
+    LLAMA_2_7B_HF = "meta-llama/Llama-2-7b-hf"
+    MISTRAL_7B_INSTRUCT_V0_3 = "mistralai/Mistral-7B-Instruct-v0.3"
+    META_LLAMA_3_8B = "meta-llama/Meta-Llama-3-8B"
+    META_LLAMA_3_8B_INSTRUCT = "meta-llama/Meta-Llama-3-8B-Instruct"
+    QWEN2_1_5B = "Qwen/Qwen2-1.5B"
+    QWEN2_1_5B_INSTRUCT = "Qwen/Qwen2-1.5B-Instruct"
+
+    @classmethod
+    def list_models(cls) -> List[str]:
+        """Return a list of supported model names as strings."""
+        return [model.value for model in cls]
+
+
 class EvaluationTask(Enum):
     MYXMATCH = "myxmatch"
+    BENCHMARK = "benchmark"
+
+
+class BenchmarkTask(Enum):
+    BIGBENCH_ANALOGICAL_SIMILARITY = "bigbench|analogical_similarity|0|0"
+    BIGBENCH_AUTHORSHIP_VERIFICATION = "bigbench|authorship_verification|0|0"
+    BIGBENCH_CODE_LINE_DESCRIPTION = "bigbench|code_line_description|0|0"
+    BIGBENCH_CONCEPTUAL_COMBINATIONS = "bigbench|conceptual_combinations|0|0"
+    BIGBENCH_LOGICAL_DEDUCTION = "bigbench|logical_deduction|0|0"
+    HARNESS_CAUSAL_JUDGMENT = "harness|bbh:causal_judgment|0|0"
+    HARNESS_DATE_UNDERSTANDING = "harness|bbh:date_understanding|0|0"
+    HARNESS_DISAMBIGUATION_QA = "harness|bbh:disambiguation_qa|0|0"
+    HARNESS_GEOMETRIC_SHAPES = "harness|bbh:geometric_shapes|0|0"
+    HARNESS_LOGICAL_DEDUCTION_FIVE_OBJECTS = (
+        "harness|bbh:logical_deduction_five_objects|0|0"
+    )
+    HELM_BABI_QA = "helm|babi_qa|0|0"
+    HELM_BBQ = "helm|bbq|0|0"
+    HELM_BOOLQ = "helm|boolq|0|0"
+    HELM_COMMONSENSEQA = "helm|commonsenseqa|0|0"
+    HELM_MMLU_PHILOSOPHY = "helm|mmlu:philosophy|0|0"
+    LEADERBOARD_ARC_CHALLENGE = "leaderboard|arc:challenge|0|0"
+    LEADERBOARD_GSM8K = "leaderboard|gsm8k|0|0"
+    LEADERBOARD_HELLASWAG = "leaderboard|hellaswag|0|0"
+    LEADERBOARD_TRUTHFULQA_MC = "leaderboard|truthfulqa:mc|0|0"
+    LEADERBOARD_MMLU_WORLD_RELIGIONS = "leaderboard|mmlu:world_religions|0|0"
+    LIGHTEVAL_ARC_EASY = "lighteval|arc:easy|0|0"
+    LIGHTEVAL_ASDIV = "lighteval|asdiv|0|0"
+    LIGHTEVAL_BIGBENCH_MOVIE_RECOMMENDATION = (
+        "lighteval|bigbench:movie_recommendation|0|0"
+    )
+    LIGHTEVAL_GLUE_COLA = "lighteval|glue:cola|0|0"
+    LIGHTEVAL_TRUTHFULQA_GEN = "lighteval|truthfulqa:gen|0|0"
+
+    @classmethod
+    def list_tasks(cls) -> List[str]:
+        """Return a list of available benchmark tasks as strings."""
+        return [task.value for task in cls]
 
 
 def list_evaluations() -> list:

--- a/remyxai/api/tasks.py
+++ b/remyxai/api/tasks.py
@@ -39,6 +39,38 @@ def run_myxmatch(name: str, prompt: str, models: list) -> dict:
         logging.error(f"Failed to create MyxMatch task: {response.status_code}")
         return {"error": f"Failed to create MyxMatch task: {response.text}"}
 
+def run_benchmark(name: str, models: list, evals: list) -> dict:
+    """Submit a benchmark task to the server."""
+
+    headers = {"Authorization": HEADERS["Authorization"]}
+
+    models_str = ",".join(models)
+    evals_str = ",".join(evals)
+    encoded_name = urllib.parse.quote(name.replace("/", "--"), safe="")
+
+    # Endpoint URL
+    url = f"{BASE_URL}/task/benchmark"
+
+    payload = {
+        "name": encoded_name,
+        "models": models_str,
+        "evals": evals_str
+    }
+
+    logging.info(f"POST request to {url} with payload: {payload}")
+
+    response = requests.post(url, headers=headers, data=payload)
+
+    if response.status_code == 202:
+        try:
+            return response.json()
+        except (requests.JSONDecodeError, ValueError) as e:
+            logging.error(f"Error decoding JSON response: {e}")
+            return {"error": "Invalid JSON response"}
+    else:
+        logging.error(f"Failed to create benchmark task: {response.status_code}")
+        return {"error": f"Failed to create benchmark task: {response.text}"}
+
 
 def get_job_status(job_name: str) -> dict:
     """

--- a/remyxai/client/remyx_client.py
+++ b/remyxai/client/remyx_client.py
@@ -9,7 +9,7 @@ from remyxai.api.models import (
     delete_model,
     download_model,
 )
-from remyxai.api.tasks import run_myxmatch, get_job_status
+from remyxai.api.tasks import run_myxmatch, run_benchmark, get_job_status
 from remyxai.api.deployment import deploy_model, download_deployment_package
 from remyxai.api.inference import run_inference
 from remyxai.api.user import get_user_profile, get_user_credits
@@ -18,6 +18,8 @@ from remyxai.api.evaluations import (
     download_evaluation,
     delete_evaluation,
     EvaluationTask,
+    BenchmarkTask,
+    EvaluationSupportedModels
 )
 from remyxai.utils.myxboard import format_results_for_storage, notify_completion
 
@@ -28,6 +30,7 @@ class RemyxAPI:
         myx_board,
         tasks: List[EvaluationTask],
         prompt: Optional[str] = None,
+        benchmark_tasks: Optional[List[str]] = None,
         on_complete: Optional[callable] = notify_completion,
     ) -> None:
         """
@@ -35,6 +38,7 @@ class RemyxAPI:
         :param myx_board: The MyxBoard to evaluate.
         :param tasks: List of tasks to evaluate.
         :param prompt: Optional prompt for tasks like MYXMATCH that require it.
+        :param benchmark_tasks: Specific benchmark tasks as strings for BENCHMARK evaluation.
         :param on_complete: Callback function to call once evaluations are complete.
         """
         try:
@@ -43,22 +47,59 @@ class RemyxAPI:
 
             for task in tasks:
                 task_name = task.value
+
+                # Handle MYXMATCH task type
                 if task == EvaluationTask.MYXMATCH:
                     if not prompt:
                         raise ValueError(f"Task '{task_name}' requires a prompt.")
 
+                    # Filter supported models from the MyxBoard models list
+                    supported_models = [
+                        model for model in myx_board.models
+                        if model in EvaluationSupportedModels.list_models()
+                    ]
+
+                    if not supported_models:
+                        raise ValueError("No supported models provided for MyxMatch evaluation.")
+
+                    formatted_models = [model.split("/")[-1] for model in myx_board.models]
                     job_response = run_myxmatch(
-                        myx_board.name, prompt, myx_board.models
+                        myx_board.name, prompt, formatted_models
                     )
 
-                    job_name = job_response.get("job_name")
-                    start_time = time.time()
+                # Handle BENCHMARK task type
+                elif task == EvaluationTask.BENCHMARK:
+                    if not benchmark_tasks:
+                        raise ValueError("Benchmark tasks must be specified for BENCHMARK evaluation.")
 
-                    myx_board.results["job_status"][task_name] = {
-                        "job_name": job_name,
-                        "status": "pending",
-                        "start_time": start_time,
-                    }
+                    # Validate and prepare benchmark tasks
+                    valid_benchmarks = BenchmarkTask.list_tasks()
+                    invalid_tasks = [bt for bt in benchmark_tasks if bt not in valid_benchmarks]
+                    if invalid_tasks:
+                        raise ValueError(f"Invalid benchmark tasks: {invalid_tasks}")
+
+                    # Filter supported models from the MyxBoard models list
+                    supported_models = [
+                        model for model in myx_board.models
+                        if model in EvaluationSupportedModels.list_models()
+                    ]
+
+                    if not supported_models:
+                        raise ValueError("No supported models provided for benchmarking.")
+
+                    # Submit the benchmark task
+                    job_response = run_benchmark(
+                        myx_board.name, supported_models, benchmark_tasks
+                    )
+
+                job_name = job_response.get("job_name")
+                start_time = time.time()
+
+                myx_board.results["job_status"][task_name] = {
+                    "job_name": job_name,
+                    "status": "pending",
+                    "start_time": start_time,
+                }
 
             myx_board._save_updates()
             print("Starting evaluation...")

--- a/remyxai/utils/myxboard.py
+++ b/remyxai/utils/myxboard.py
@@ -1,3 +1,4 @@
+import math
 import logging
 from typing import List
 from datetime import datetime, timezone
@@ -6,12 +7,19 @@ from datetime import datetime, timezone
 def notify_completion():
     print("Evaluations are done! You can now view the results.")
 
+def sanitize_float(value):
+    """
+    Replace NaN, Infinity, and -Infinity with a valid default value (e.g., None or 0.0).
+    """
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return 0.0  # Replace with 0.0 if you prefer numerical default
+    return value
 
-def format_results_for_storage(
+def format_myxmatch_results_for_storage(
     eval_results: dict, task_name: str, start_time: float, end_time: float
 ) -> list:
     """
-    Format evaluation results into the internal schema used for storage.
+    Format myxmatch evaluation results into the internal schema used for storage.
     """
     formatted_results = []
 
@@ -47,6 +55,72 @@ def format_results_for_storage(
     logging.info(f"Formatted results: {formatted_results}")
     return formatted_results
 
+def format_results_for_storage(
+    eval_results: dict, task_name: str, start_time: float, end_time: float
+) -> list:
+    """
+    Dispatch to the correct formatter based on the task type.
+    """
+    if task_name == "myxmatch":
+        return format_myxmatch_results_for_storage(eval_results, task_name, start_time, end_time)
+    elif task_name == "benchmark":
+        return format_benchmark_results_for_storage(eval_results, task_name, start_time, end_time)
+    else:
+        logging.error(f"Unsupported task type: {task_name}")
+        return []
+
+def format_benchmark_results_for_storage(
+    eval_results: dict, task_name: str, start_time: float, end_time: float
+) -> list:
+    """
+    Format evaluation results for 'benchmark' tasks into the internal schema used for storage.
+    """
+    formatted_results = []
+
+    # Ensure eval_results contains the "benchmark" key
+    if not isinstance(eval_results, dict) or "benchmark" not in eval_results:
+        logging.error(f"Invalid format for eval_results: {eval_results}")
+        return formatted_results
+
+    benchmark_results = eval_results.get("benchmark", [])
+    if not isinstance(benchmark_results, list):
+        logging.error(f"Unexpected format for benchmark results: {benchmark_results}")
+        return formatted_results
+
+    for model_eval in benchmark_results:
+        model_name = model_eval.get("model")
+        if not model_name:
+            logging.warning(f"Skipping entry with missing 'model': {model_eval}")
+            continue
+
+        # Sanitize and dynamically extract metrics
+        model_results = {
+            key: {k: sanitize_float(v) for k, v in value.items()}
+            if isinstance(value, dict)
+            else sanitize_float(value)
+            for key, value in model_eval.items()
+            if key != "model"  # Exclude the "model" key itself
+        }
+
+        formatted_results.append(
+            {
+                "config_general": {
+                    "model_name": model_name,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                },
+                "results": model_results,
+                "details": {
+                    "evaluation_type": task_name,
+                    "eval_tasks": eval_results.get("eval_tasks", ""),
+                    "execution_time": eval_results.get("execution_time", ""),
+                    "run_id": eval_results.get("run_id", ""),
+                },
+            }
+        )
+
+    logging.info(f"Formatted results: {formatted_results}")
+    return formatted_results
 
 def _reorder_models_by_results(results: dict, task_name: str) -> list:
     """
@@ -61,26 +135,20 @@ def _reorder_models_by_results(results: dict, task_name: str) -> list:
     return [model_id for model_id, _ in ranked_models]
 
 
-def _validate_models(models: List[str], supported_models: List[str]) -> None:
+def _validate_models(models: list, supported_models: list) -> None:
     """
-    Validate that the models in the MyxBoard are supported.
-    This function does not modify the models list but raises an exception for unsupported models.
-    :param models: List of model names to validate.
-    :param supported_models: List of supported model names.
+    Validate that all models in `models` are in the supported models list.
+    Raise a ValueError if any model is not supported.
     """
-    for model in models:
-        # If HF repo, map it to the supported name for validation
-        if "/" in model:
-            mapped_model = model.split("/")[1]
-        else:
-            mapped_model = model
+    # Ensure models are valid
+    unsupported_models = [model for model in models if model not in supported_models]
 
-        if mapped_model not in supported_models:
-            raise ValueError(
-                f"Model '{model}' is not supported. Supported models: {supported_models}"
-            )
+    if unsupported_models:
+        raise ValueError(
+            f"The following models are not supported: {unsupported_models}. "
+            f"Supported models: {supported_models}"
+        )
     logging.info(f"Validated models: {models}")
-
 
 def get_start_end_times(job_status_response):
     """


### PR DESCRIPTION
This PR helps include `benchmark` task capabilities to the evaluation suite. Using MyxBoard, a user can request and track multiple types of evaluations. 

## Testing
The new way of using the MyxBoard object and requesting evaluations is as follows. MyxBoards can still also be created from hf collections.
```python
# imports
from remyxai.client.myxboard import MyxBoard
from remyxai.api.evaluations import EvaluationSupportedModels, EvaluationTask, BenchmarkTask
from remyxai.client.remyx_client import RemyxAPI

# View available models 
print(EvaluationSupportedModels.list_models())

# View available benchmark evals
print(BenchmarkTask.list_tasks())

model_ids = ['microsoft/Phi-3-mini-4k-instruct','Qwen/Qwen2-1.5B']
myx_board_name = "test_myxboard_bench_myxmatch_18"
myx_board = MyxBoard(model_repo_ids=model_ids, name=myx_board_name)
tasks = [EvaluationTask.MYXMATCH, EvaluationTask.BENCHMARK]
bench_tasks = ['leaderboard|truthfulqa:mc|0|0']
prompt = "You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis."

remyx_api = RemyxAPI()
remyx_api.evaluate(myx_board, tasks, prompt=prompt, benchmark_tasks=bench_tasks)
results = myx_board.get_results()

# should see results like:
# {'myxmatch': [{'model': 'Phi-3-mini-4k-instruct',
   'rank': 1,
   'prompt': 'You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis.'},
  {'model': 'Qwen2-1.5B',
   'rank': 2,
   'prompt': 'You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis.'}],
 'benchmark': [{'model': 'microsoft/Phi-3-mini-4k-instruct',
   'metrics': {'leaderboard|truthfulqa:mc|0|0': {'truthfulqa_mc1': 0.36107711138310894,
     'truthfulqa_mc1_stderr': 0.016814312844836886,
     'truthfulqa_mc2': 0.5447221529227565,
     'truthfulqa_mc2_stderr': 0.015122757336231507}},
   'eval_tasks': 'leaderboard|truthfulqa:mc|0|0',
   'execution_time': '09:38 November 15, 2024',
   'run_id': '2ad3d47d37724301bf28ef8979553b82'},
  {'model': 'Qwen/Qwen2-1.5B',
   'metrics': {'leaderboard|truthfulqa:mc|0|0': {'truthfulqa_mc1': 1.0,
     'truthfulqa_mc1_stderr': 0.0,
     'truthfulqa_mc2': 0.0,
     'truthfulqa_mc2_stderr': 0.0}},
   'eval_tasks': 'leaderboard|truthfulqa:mc|0|0',
   'execution_time': '09:38 November 15, 2024',
   'run_id': '2ad3d47d37724301bf28ef8979553b82'}]}
```