### PR TITLE
Expanding model support for MyxMatch

### DIFF
--- a/remyxai/api/evaluations.py
+++ b/remyxai/api/evaluations.py
@@ -13,7 +13,7 @@ class AvailableArchitectures:
         self.architectures = self._load_architectures()
 
     def _load_architectures(self):
-        architectures = fetch_available_architectures()
+        architectures = fetch_available_architectures()["message"]
         if not architectures:
             logging.warning("Using empty model list due to fetch error.")
         return architectures

--- a/remyxai/api/evaluations.py
+++ b/remyxai/api/evaluations.py
@@ -5,7 +5,6 @@ from enum import Enum
 from remyxai.api.models import fetch_available_architectures
 from . import BASE_URL, HEADERS
 
-
 class AvailableArchitectures:
     """
     Class to interact with the list of available model architectures.
@@ -24,6 +23,23 @@ class AvailableArchitectures:
 
     def is_architecture_available(self, architecture_name):
         return architecture_name in self.architectures
+
+class AvailableModels(Enum):
+    PHI_3_MINI_4K_INSTRUCT = "microsoft/Phi-3-mini-4k-instruct"
+    BIOMISTRAL_7B = "BioMistral/BioMistral-7B"
+    CODELLAMA_7B_INSTRUCT_HF = "codellama/CodeLlama-7b-Instruct-hf"
+    GORILLA_OPENFUNCTIONS_V2 = "gorilla-llm/gorilla-openfunctions-v2"
+    LLAMA_2_7B_HF = "meta-llama/Llama-2-7b-hf"
+    MISTRAL_7B_INSTRUCT_V0_3 = "mistralai/Mistral-7B-Instruct-v0.3"
+    META_LLAMA_3_8B = "meta-llama/Meta-Llama-3-8B"
+    META_LLAMA_3_8B_INSTRUCT = "meta-llama/Meta-Llama-3-8B-Instruct"
+    QWEN2_1_5B = "Qwen/Qwen2-1.5B"
+    QWEN2_1_5B_INSTRUCT = "Qwen/Qwen2-1.5B-Instruct"
+
+    @classmethod
+    def list_models(cls) -> List[str]:
+        """Return a list of supported model names as strings."""
+        return [model.value for model in cls]
 
 class EvaluationTask(Enum):
     MYXMATCH = "myxmatch"

--- a/remyxai/api/evaluations.py
+++ b/remyxai/api/evaluations.py
@@ -2,27 +2,28 @@ import logging
 import requests
 from typing import List
 from enum import Enum
+from remyxai.api.models import fetch_available_architectures
 from . import BASE_URL, HEADERS
 
 
-# More models coming soon
-class AvailableModels(Enum):
-    PHI_3_MINI_4K_INSTRUCT = "microsoft/Phi-3-mini-4k-instruct"
-    BIOMISTRAL_7B = "BioMistral/BioMistral-7B"
-    CODELLAMA_7B_INSTRUCT_HF = "codellama/CodeLlama-7b-Instruct-hf"
-    GORILLA_OPENFUNCTIONS_V2 = "gorilla-llm/gorilla-openfunctions-v2"
-    LLAMA_2_7B_HF = "meta-llama/Llama-2-7b-hf"
-    MISTRAL_7B_INSTRUCT_V0_3 = "mistralai/Mistral-7B-Instruct-v0.3"
-    META_LLAMA_3_8B = "meta-llama/Meta-Llama-3-8B"
-    META_LLAMA_3_8B_INSTRUCT = "meta-llama/Meta-Llama-3-8B-Instruct"
-    QWEN2_1_5B = "Qwen/Qwen2-1.5B"
-    QWEN2_1_5B_INSTRUCT = "Qwen/Qwen2-1.5B-Instruct"
+class AvailableArchitectures:
+    """
+    Class to interact with the list of available model architectures.
+    """
+    def __init__(self):
+        self.architectures = self._load_architectures()
 
-    @classmethod
-    def list_models(cls) -> List[str]:
-        """Return a list of supported model names as strings."""
-        return [model.value for model in cls]
+    def _load_architectures(self):
+        architectures = fetch_available_architectures()
+        if not architectures:
+            logging.warning("Using empty model list due to fetch error.")
+        return architectures
 
+    def list_architectures(self):
+        return self.architectures
+
+    def is_architecture_available(self, architecture_name):
+        return architecture_name in self.architectures
 
 class EvaluationTask(Enum):
     MYXMATCH = "myxmatch"

--- a/remyxai/api/models.py
+++ b/remyxai/api/models.py
@@ -7,31 +7,31 @@ from . import BASE_URL, HEADERS, log_api_response
 
 @lru_cache(maxsize=1)
 def fetch_available_architectures():
-    url = f"{BASE_URL}model/architectures"
+    url = f"{BASE_URL}/model/architectures"
     response = requests.get(url)
     architectures = response.json()
     return architectures
 
 def list_models():
-    url = f"{BASE_URL}model/list"
+    url = f"{BASE_URL}/model/list"
     response = requests.get(url, headers=HEADERS)
     return response.json()
 
 
 def get_model_summary(model_name):
-    url = f"{BASE_URL}model/summary/{model_name}"
+    url = f"{BASE_URL}/model/summary/{model_name}"
     response = requests.get(url, headers=HEADERS)
     return response.json()
 
 
 def delete_model(model_name: str):
-    url = f"{BASE_URL}model/delete/{model_name}"
+    url = f"{BASE_URL}/model/delete/{model_name}"
     response = requests.post(url, headers=HEADERS)
     return response.json()
 
 
 def download_model(model_name: str, model_format: str):
-    url = f"{BASE_URL}model/download/{model_name}/{model_format}"
+    url = f"{BASE_URL}/model/download/{model_name}/{model_format}"
     response = requests.post(url, headers=HEADERS, stream=True)
 
     if response.status_code == 200:

--- a/remyxai/api/models.py
+++ b/remyxai/api/models.py
@@ -2,8 +2,15 @@ import os
 import shutil
 import requests
 from io import BytesIO
+from functools import lru_cache
 from . import BASE_URL, HEADERS, log_api_response
 
+@lru_cache(maxsize=1)
+def fetch_available_architectures():
+    url = f"{BASE_URL}model/architectures"
+    response = requests.get(url)
+    architectures = response.json()
+    return architectures
 
 def list_models():
     url = f"{BASE_URL}model/list"

--- a/remyxai/api/tasks.py
+++ b/remyxai/api/tasks.py
@@ -7,24 +7,14 @@ from typing import Optional
 
 def run_myxmatch(name: str, prompt: str, models: list) -> dict:
     """Submit a MyxMatch task to the server."""
-    mapped_models = []
-    for model in models:
-        if "/" in model:
-            mapped_model = model.split("/")[1]
-        else:
-            mapped_model = model
+    headers = {"Authorization": HEADERS["Authorization"]}
+    models_str = ",".join(models)
 
-        mapped_models.append(mapped_model)
-
-    models_str = ",".join(mapped_models)
-
-    encoded_name = urllib.parse.quote(name.replace("/", "--"), safe="")
-    encoded_prompt = urllib.parse.quote(prompt, safe="")
-
-    url = f"{BASE_URL}/task/myxmatch/{encoded_name}/{encoded_prompt}/{models_str}"
+    url = f"{BASE_URL}/task/myxmatch"
     logging.info(f"POST request to {url}")
+    payload = {"name": name, "models": models_str, "prompt": prompt}
 
-    response = requests.post(url, headers=HEADERS)
+    response = requests.post(url, headers=headers, data=payload)
 
     if response.status_code == 202:
         try:

--- a/remyxai/client/myxboard.py
+++ b/remyxai/client/myxboard.py
@@ -14,10 +14,10 @@ from remyxai.api.myxboard import (
 )
 from remyxai.utils.myxboard import (
     _reorder_models_by_results,
-    _validate_models,
     add_code_snippet_to_card,
     format_results_for_storage,
 )
+from remyxai.utils.validators import _validate_models
 import pandas as pd
 from datasets import Dataset, DatasetDict
 from huggingface_hub import (
@@ -47,7 +47,7 @@ class MyxBoard:
             self.models = model_repo_ids or []
             self.from_hf_collection = False
 
-        _validate_models(self.models, AvailableModels.list_models())
+        _validate_models(self.models)
         self.results = {}
         self.job_status = {}
 

--- a/remyxai/client/myxboard.py
+++ b/remyxai/client/myxboard.py
@@ -3,7 +3,7 @@ import time
 import logging
 from typing import List, Dict, Optional, Union
 import urllib.parse
-from remyxai.api.evaluations import EvaluationTask, AvailableModels, download_evaluation
+from remyxai.api.evaluations import EvaluationTask, download_evaluation
 from remyxai.api.tasks import get_job_status
 from remyxai.api.myxboard import (
     list_myxboards,

--- a/remyxai/client/remyx_client.py
+++ b/remyxai/client/remyx_client.py
@@ -19,9 +19,10 @@ from remyxai.api.evaluations import (
     delete_evaluation,
     EvaluationTask,
     BenchmarkTask,
-    AvailableModels,
+    AvailableModels
 )
 from remyxai.utils.myxboard import format_results_for_storage, notify_completion
+from remyxai.utils.validators import _validate_models
 
 
 class RemyxAPI:
@@ -52,22 +53,10 @@ class RemyxAPI:
                     if not prompt:
                         raise ValueError(f"Task '{task_name}' requires a prompt.")
 
-                    supported_models = [
-                        model
-                        for model in myx_board.models
-                        if model in AvailableModels.list_models()
-                    ]
+                    _validate_models(myx_board.models)
 
-                    if not supported_models:
-                        raise ValueError(
-                            "No supported models provided for MyxMatch evaluation."
-                        )
-
-                    formatted_models = [
-                        model.split("/")[-1] for model in myx_board.models
-                    ]
                     job_response = run_myxmatch(
-                        myx_board.name, prompt, formatted_models
+                        myx_board.name, prompt, myx_board.models
                     )
 
                 elif task == EvaluationTask.BENCHMARK:

--- a/remyxai/utils/myxboard.py
+++ b/remyxai/utils/myxboard.py
@@ -141,21 +141,6 @@ def _reorder_models_by_results(results: dict, task_name: str) -> list:
     return [model_id for model_id, _ in ranked_models]
 
 
-def _validate_models(models: list, supported_models: list) -> None:
-    """
-    Validate that all models in `models` are in the supported models list.
-    Raise a ValueError if any model is not supported.
-    """
-    unsupported_models = [model for model in models if model not in supported_models]
-
-    if unsupported_models:
-        raise ValueError(
-            f"The following models are not supported: {unsupported_models}. "
-            f"Supported models: {supported_models}"
-        )
-    logging.info(f"Validated models: {models}")
-
-
 def get_start_end_times(job_status_response):
     """
     Extract start and end times from job status response.

--- a/remyxai/utils/validators.py
+++ b/remyxai/utils/validators.py
@@ -4,7 +4,7 @@ import logging
 import requests
 from typing import List, Tuple, Optional
 from huggingface_hub import HfFolder
-from remyxai.api.models import fetch_supported_architectures
+from remyxai.api.models import fetch_available_architectures
 
 def get_hf_token() -> Optional[str]:
     """
@@ -45,7 +45,7 @@ def validate_model_architecture(
                 return True, f"Model '{model_id}' matches architecture: {architecture}"
 
         return False, (
-            f"Model '{model_id}' does not match any supported architectures: {supported_archs}"
+            f"Model '{model_id}' does not match any supported architectures: {', '.join(supported_archs)}"
         )
 
     except requests.exceptions.HTTPError as e:
@@ -117,7 +117,7 @@ def _validate_models(
     Automatically fetches the user's HF token from the environment.
     """
     # Fetch the supported architectures once
-    supported_archs = fetch_supported_architectures()
+    supported_archs = fetch_available_architectures()["message"]
     if not supported_archs:
         raise ValueError("Failed to fetch supported architectures from server.")
 
@@ -141,3 +141,4 @@ def _validate_models(
     if invalid_models:
         error_messages = "\n".join(reasons)
         raise ValueError(f"The following models failed validation:\n{error_messages}")
+

--- a/remyxai/utils/validators.py
+++ b/remyxai/utils/validators.py
@@ -1,0 +1,143 @@
+import os
+import re
+import logging
+import requests
+from typing import List, Tuple, Optional
+from huggingface_hub import HfFolder
+from remyxai.api.models import fetch_supported_architectures
+
+def get_hf_token() -> Optional[str]:
+    """
+    Fetches the Hugging Face token from the user's environment.
+    Tries environment variable 'HF_TOKEN' first, then the Hugging Face cache.
+    """
+    hf_token = os.getenv('HF_TOKEN')
+    if hf_token:
+        return hf_token
+    hf_token = HfFolder.get_token()
+    return hf_token
+
+def get_headers(hf_token: Optional[str]):
+    headers = {}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    return headers
+
+def validate_model_architecture(
+    model_id: str, supported_archs: List[str], hf_token: Optional[str]
+) -> Tuple[bool, str]:
+    """
+    Validates if a model's architecture matches any known architectures from the server.
+    """
+    try:
+        api_url = f"https://huggingface.co/{model_id}/raw/main/config.json"
+        response = requests.get(api_url, headers=get_headers(hf_token), timeout=10)
+        response.raise_for_status()
+
+        config = response.json()
+        architectures = config.get("architectures", [])
+
+        if not supported_archs:
+            return False, "Supported architectures list is empty."
+
+        for architecture in architectures:
+            if architecture in supported_archs:
+                return True, f"Model '{model_id}' matches architecture: {architecture}"
+
+        return False, (
+            f"Model '{model_id}' does not match any supported architectures: {supported_archs}"
+        )
+
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 404:
+            return False, f"Model '{model_id}' does not exist or is not accessible."
+        else:
+            return False, f"HTTP error fetching model config for '{model_id}': {e}"
+    except requests.exceptions.RequestException as e:
+        return False, f"Request error fetching model config for '{model_id}': {e}"
+    except KeyError:
+        return False, f"Invalid configuration format for '{model_id}'"
+    except Exception as e:
+        logging.error(f"Unexpected error during architecture validation: {e}")
+        return False, f"Unexpected error during validation: {e}"
+
+def validate_model_size(model_id: str, max_size_billion: int = 8) -> Tuple[bool, str]:
+    """
+    Validates a model's size based on its repository name convention.
+    """
+    pattern = r"(\d+(\.\d+)?)([BM])"
+    match = re.search(pattern, model_id)
+
+    if not match:
+        return True, (
+            f"Model size for '{model_id}' could not be determined from the name; "
+            "assumed valid."
+        )
+
+    size_str, _, unit = match.groups()
+    size = float(size_str)
+
+    if unit.upper() == "M":
+        size /= 1000  # Convert millions to billions if necessary
+
+    if size <= max_size_billion:
+        return True, (
+            f"Model '{model_id}' size ({size}B) is within the allowed limit of "
+            f"{max_size_billion}B."
+        )
+    else:
+        return False, (
+            f"Model '{model_id}' size ({size}B) exceeds the allowed limit of "
+            f"{max_size_billion}B."
+        )
+
+def validate_model(
+    model_id: str, supported_archs: List[str], hf_token: Optional[str], max_size_billion: int = 8
+) -> Tuple[bool, str]:
+    """
+    Validates a model based on its architecture and size.
+    """
+    is_architecture_valid, arch_reason = validate_model_architecture(
+        model_id, supported_archs, hf_token
+    )
+    if not is_architecture_valid:
+        return False, arch_reason
+
+    is_size_valid, size_reason = validate_model_size(model_id, max_size_billion)
+    if not is_size_valid:
+        return False, size_reason
+
+    return True, f"Model '{model_id}' passed validation for architecture and size."
+
+def _validate_models(
+    models: List[str], max_size_billion: int = 8
+):
+    """
+    Validates a list of models, raising an exception if any fail validation.
+    Automatically fetches the user's HF token from the environment.
+    """
+    # Fetch the supported architectures once
+    supported_archs = fetch_supported_architectures()
+    if not supported_archs:
+        raise ValueError("Failed to fetch supported architectures from server.")
+
+    # Fetch the HF token
+    hf_token = get_hf_token()
+    if not hf_token:
+        logging.warning("No Hugging Face token found; only public models can be validated.")
+
+    invalid_models = []
+    reasons = []
+
+    for model in models:
+        is_valid, reason = validate_model(model, supported_archs, hf_token, max_size_billion)
+        if not is_valid:
+            invalid_models.append(model)
+            reasons.append(reason)
+            logging.warning(reason)
+        else:
+            logging.info(reason)
+
+    if invalid_models:
+        error_messages = "\n".join(reasons)
+        raise ValueError(f"The following models failed validation:\n{error_messages}")


### PR DESCRIPTION
This PR helps expand the available models to evaluate through MyxMatch. We introduce additional validators to confirm availability offline before job submission.

## Test
To test this latest change, you can try running a new myxmatch evaluation:
```python
from remyxai.client.myxboard import MyxBoard
from remyxai.api.evaluations import (
    EvaluationTask,
    BenchmarkTask
    )
from remyxai.client.remyx_client import RemyxAPI

myx_board_name = "small-llm-comparison-media_example"
model_ids = ["microsoft/Phi-3-mini-4k-instruct", "Qwen/Qwen2-1.5B"]
myx_board = MyxBoard(model_repo_ids=model_ids, name=myx_board_name)

tasks = [EvaluationTask.MYXMATCH]
prompt = "You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis."

remyx_api = RemyxAPI()
remyx_api.evaluate(myx_board, tasks, prompt=prompt)
>> Starting evaluation...

>>Evaluations are done! You can now view the results.
results = myx_board.get_results()

results
>>
{'myxmatch': [{'model': 'microsoft/Phi-3-mini-4k-instruct',
   'rank': 1,
   'prompt': 'You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis.'},
  {'model': 'Qwen/Qwen2-1.5B',
   'rank': 2,
   'prompt': 'You are a media analyst. Objective: Analyze the media coverage. Phase 1: Begin analysis.'}]}
```