### PR TITLE
Update validation for Benchmark

### DIFF
--- a/remyxai/api/evaluations.py
+++ b/remyxai/api/evaluations.py
@@ -24,23 +24,6 @@ class AvailableArchitectures:
     def is_architecture_available(self, architecture_name):
         return architecture_name in self.architectures
 
-class AvailableModels(Enum):
-    PHI_3_MINI_4K_INSTRUCT = "microsoft/Phi-3-mini-4k-instruct"
-    BIOMISTRAL_7B = "BioMistral/BioMistral-7B"
-    CODELLAMA_7B_INSTRUCT_HF = "codellama/CodeLlama-7b-Instruct-hf"
-    GORILLA_OPENFUNCTIONS_V2 = "gorilla-llm/gorilla-openfunctions-v2"
-    LLAMA_2_7B_HF = "meta-llama/Llama-2-7b-hf"
-    MISTRAL_7B_INSTRUCT_V0_3 = "mistralai/Mistral-7B-Instruct-v0.3"
-    META_LLAMA_3_8B = "meta-llama/Meta-Llama-3-8B"
-    META_LLAMA_3_8B_INSTRUCT = "meta-llama/Meta-Llama-3-8B-Instruct"
-    QWEN2_1_5B = "Qwen/Qwen2-1.5B"
-    QWEN2_1_5B_INSTRUCT = "Qwen/Qwen2-1.5B-Instruct"
-
-    @classmethod
-    def list_models(cls) -> List[str]:
-        """Return a list of supported model names as strings."""
-        return [model.value for model in cls]
-
 class EvaluationTask(Enum):
     MYXMATCH = "myxmatch"
     BENCHMARK = "benchmark"

--- a/remyxai/client/remyx_client.py
+++ b/remyxai/client/remyx_client.py
@@ -19,7 +19,6 @@ from remyxai.api.evaluations import (
     delete_evaluation,
     EvaluationTask,
     BenchmarkTask,
-    AvailableModels
 )
 from remyxai.utils.myxboard import format_results_for_storage, notify_completion
 from remyxai.utils.validators import _validate_models
@@ -49,11 +48,11 @@ class RemyxAPI:
             for task in tasks:
                 task_name = task.value
 
+                _validate_models(myx_board.models)
+
                 if task == EvaluationTask.MYXMATCH:
                     if not prompt:
                         raise ValueError(f"Task '{task_name}' requires a prompt.")
-
-                    _validate_models(myx_board.models)
 
                     job_response = run_myxmatch(
                         myx_board.name, prompt, myx_board.models
@@ -72,19 +71,8 @@ class RemyxAPI:
                     if invalid_tasks:
                         raise ValueError(f"Invalid benchmark tasks: {invalid_tasks}")
 
-                    supported_models = [
-                        model
-                        for model in myx_board.models
-                        if model in AvailableModels.list_models()
-                    ]
-
-                    if not supported_models:
-                        raise ValueError(
-                            "No supported models provided for benchmarking."
-                        )
-
                     job_response = run_benchmark(
-                        myx_board.name, supported_models, benchmark_tasks
+                        myx_board.name, myx_board.models, benchmark_tasks
                     )
 
                 job_name = job_response.get("job_name")


### PR DESCRIPTION
This PR updates the validation mechanism to use the `_validate_models()` helper instead of using the limited `AvailableModels` enumerator. 
This will validate models on architecture and param count.

To test, run:
```python
from remyxai.api.tasks import  run_benchmark

name = "test_benchmark_expand_arch_example"
models = ["Qwen/Qwen2-0.5B"]  
evals = ["leaderboard|truthfulqa:mc|0|0"] 
response = run_benchmark(name, models, evals)
```

Successfully created a valid job with the example above.