### PR TITLE
Fix huggingface_hub>=1.0 import: drop HfFolder, reuse get_hf_token

### DIFF
--- a/remyxai/client/myxboard.py
+++ b/remyxai/client/myxboard.py
@@ -17,16 +17,15 @@ from remyxai.utils.myxboard import (
     add_code_snippet_to_card,
     format_results_for_storage,
 )
-from remyxai.utils.validators import _validate_models
+from remyxai.utils.validators import _validate_models, get_hf_token
 import pandas as pd
 from datasets import Dataset, DatasetDict
 from huggingface_hub import (
     create_repo,
     get_collection,
     add_collection_item,
-    HfFolder,
     DatasetCard,
-    whoami
+    whoami,
 )
 
 
@@ -276,7 +275,7 @@ class MyxBoard:
                 dataset_name = self.hf_collection_name.rsplit("-", 1)[0]
             else:
                 # Check if the Hugging Face token is missing
-                token = HfFolder.get_token() or os.getenv("HF_TOKEN")
+                token = get_hf_token()
                 if not token:
                     logging.error("Missing Hugging Face token - Please authenticate with: huggingface_cli login")
                     raise
@@ -311,7 +310,7 @@ class MyxBoard:
         return DatasetDict({"results": dataset})
 
     def _push_dataset_to_hf(self, dataset_name: str, dataset_dict: DatasetDict) -> None:
-        token = HfFolder.get_token() or os.getenv("HF_TOKEN")
+        token = get_hf_token()
 
         if not token:
             raise EnvironmentError("No Hugging Face token found.")


### PR DESCRIPTION
## Summary

`huggingface_hub` removed `HfFolder` in 1.x. The import at `remyxai/client/myxboard.py:23-30` broke CLI startup entirely on any install with `huggingface_hub>=1.0` — `remyxai --help` and every subcommand failed at module load with:

```
ImportError: cannot import name 'HfFolder' from 'huggingface_hub'
```

## Root cause

`remyxai/client/myxboard.py` imported `HfFolder` directly with no fallback, even though `remyxai/utils/validators.py` already had a forward-compatible `get_hf_token()` helper that handles both the old (`HfFolder.get_token`) and new (`get_token`) huggingface_hub APIs.

## Fix

Three small changes in `remyxai/client/myxboard.py`:

1. Drop `HfFolder` from the top-level import
2. Import `get_hf_token` from `validators` alongside the existing `_validate_models` import
3. Replace the two `HfFolder.get_token() or os.getenv("HF_TOKEN")` call sites with `get_hf_token()` — the helper already checks `HF_TOKEN` env var before falling through to the HF cache

## Verification

Before this PR, on huggingface_hub 1.17.0:

```
$ remyxai --help
ImportError: cannot import name 'HfFolder' from 'huggingface_hub'
```

After this PR:

```
$ remyxai --help
Usage: remyxai [OPTIONS] COMMAND [ARGS]...

  RemyxAI CLI - ExperimentOps for AI Development

Commands:
  dataset            Manage datasets.
  deploy-model       Deploy or tear down a model.
  evaluate-myxboard  Evaluate the MyxBoard with the given models and tasks.
  interests          Manage Research Interest profiles.
  list-models        List all available models.
  papers             Daily recommendations from Remyx AI GitRank.
  search             Search and discover research assets (papers + Docker...
  summarize-model    Summarize a model.
```

## Backward compat

No behavior change for `huggingface_hub<1.0` — `get_hf_token()` already matched the old `HfFolder` semantics.

## Unblocks

[remyxai/remyxai-cli#34](https://github.com/remyxai/remyxai-cli/pull/34) (Outrider subcommand) had to test against the leaf module directly because importing through `commands.py` triggered this error. With this fix merged, the next PR can re-add CLI-wiring tests using `CliRunner` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)