### PR TITLE
Release tooling: v0.2.7 + PyPI publish workflow (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+# Cuts a release to PyPI when a GitHub Release is published.
+# Auth is PyPI Trusted Publishing (OIDC) — no API token is stored.
+# One-time setup on pypi.org → project "remyxai" → Publishing → add a
+# GitHub trusted publisher with:
+#   Owner: remyxai   Repository: remyxai-cli
+#   Workflow: publish.yml   Environment: pypi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+# Build configuration. Package metadata lives in setup.py (single source of
+# truth for version, deps, entry points); this file just declares the build
+# backend so `python -m build` is reproducible.
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="remyxai",
-    version="0.2.6",
+    version="0.2.7",
     packages=find_packages(include=["remyxai", "remyxai.*"]),
     install_requires=[
         "click",


### PR DESCRIPTION
Follow-up to #34. Makes `remyxai` pip-installable without cloning.

## Changes
- **`setup.py`** — version `0.2.6` → **`0.2.7`** (patch over the unpublished 0.2.6; PyPI latest is 0.2.5).
- **`pyproject.toml`** (new) — declares the setuptools build backend so `python -m build` is reproducible. Metadata stays in `setup.py` (single source of truth).
- **`.github/workflows/publish.yml`** (new) — on a *published GitHub Release*, builds the sdist + wheel, runs `twine check`, and uploads to PyPI via **Trusted Publishing (OIDC)** — no API token stored (`permissions: id-token: write`).

## Verified locally
`python -m build` produces `remyxai-0.2.7.tar.gz` + `remyxai-0.2.7-py3-none-any.whl`, both **pass `twine check`**.

---

## Release runbook (Trusted Publishing)

### 1. PyPI — add the trusted publisher (one-time)
Must be an owner/maintainer of the project.
1. Sign in to pypi.org → **https://pypi.org/manage/project/remyxai/settings/publishing/** (project → Manage → Publishing).
2. Under **Add a new publisher → GitHub**, enter exactly:
   - **Owner:** `remyxai`
   - **Repository name:** `remyxai-cli`
   - **Workflow name:** `publish.yml` (filename only)
   - **Environment name:** `pypi`
3. **Add.** (No PyPI API token is used or stored.)

### 2. GitHub — create the `pypi` environment (one-time)
Must match the workflow's `environment: pypi` and the PyPI config above.
1. Repo → **Settings → Environments → New environment** → name **`pypi`** → save.
2. (Optional) restrict deployment to tags like `v*`.

### 3. Merge this PR
So `publish.yml` + the `0.2.7` bump land on `main`; cut the release from `main`.

### 4. Cut the release (this publishes)
1. Repo → **Releases → Draft a new release**.
2. **Choose a tag** → `v0.2.7` → create on publish, target `main`.
3. Title `v0.2.7` → **Publish release** → fires the `Publish to PyPI` workflow.

### 5. Verify
- Actions → **Publish to PyPI** run is green.
- https://pypi.org/project/remyxai/0.2.7/ and `pip install remyxai==0.2.7`.

> Order matters: do steps 1–2 **before** publishing the release. `0.2.6` was never published; `0.2.5 → 0.2.7` is fine (PyPI allows version gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
