### PR TITLE
Create interests from repo and project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ remyxai interests create \
   --name "LLM Efficiency" \
   --context "Quantization, speculative decoding, KV cache compression"
 
-# Or seed from a GitHub repo (auto-extracts context)
-remyxai interests create --context "https://github.com/your-org/your-repo"
+# From a GitHub repo, or from one of your projects
+remyxai interests from-repo https://github.com/your-org/your-repo
+remyxai interests from-project "Spatial VQA"
 ```
 
-The recommendation pipeline matches new arXiv papers to your interests daily. First run takes 40-120s to populate the pool; subsequent runs are instant.
+The pipeline matches new arXiv papers to your interests daily. See [Research Interests](#research-interests) for all three ways to create one.
 
 **Install Outrider on a repo**
 
@@ -48,7 +49,84 @@ The recommendation pipeline matches new arXiv papers to your interests daily. Fi
 remyxai outrider init --repo owner/name --auto-interest
 ```
 
-Drives the Remyx engine to install [Outrider](https://github.com/remyxai/outrider) on the target repo via the Remyx GitHub App: writes the workflow, sets the repo secrets, and opens a bot-authored setup PR. Your local git isn't touched. Requires `REMYXAI_API_KEY` and an Anthropic key for Claude Code (`--anthropic-key` or `ANTHROPIC_API_KEY`).
+Sets up [Outrider](https://github.com/remyxai/outrider) on the target repo, server-side — your local git is never touched. See [Outrider](#outrider) for what it configures and the credentials it needs.
+
+## Research Interests
+
+A Research Interest is a named description of what to track; the recommendation pipeline matches new arXiv papers (and other sources) to it. Every create command kicks off a first recommendation pass automatically so the interest is populated right away — add `--wait` to block until the picks are ready, or `--no-refresh` to skip.
+
+### From free-form context
+
+```bash
+remyxai interests create \
+  --name "LLM Efficiency" \
+  --context "Quantization, speculative decoding, KV cache compression"
+```
+
+`--context` also accepts a HuggingFace or GitHub URL, which the server expands into context.
+
+### From a GitHub repo
+
+`remyxai interests from-repo <github-url>` analyzes the repo, generates a profile of the project (themes, architecture, history), and uses it as the interest's context:
+
+```bash
+remyxai interests from-repo https://github.com/your-org/your-repo \
+  --name "My Project" --daily-count 3 --automate review --wait
+```
+
+- `--automate {none|review|auto}` — paper-PR automation on the repo: `none` (default; just create the interest), `review` (open a setup PR to review), or `auto` (set it up automatically). For the full repo setup, see [Outrider](#outrider).
+
+### From a project
+
+`remyxai interests from-project <name-or-uuid>` builds the interest's context from a project's experiments:
+
+```bash
+# Track all experiments on the project
+remyxai interests from-project "Spatial VQA" --wait
+
+# Or curate a subset, and pin the context
+remyxai interests from-project <uuid> -e "baseline-run" -e "dpo-v2" --no-auto-update
+```
+
+- `-e/--include-experiment` — track a specific experiment (repeatable); omit to track all.
+- `--no-auto-update` — pin the context instead of refreshing as new experiments land.
+
+## Outrider
+
+[Outrider](https://github.com/remyxai/outrider) is a GitHub Action that opens pull requests integrating relevant new papers into a repo. `remyxai outrider init` sets it up for you, server-side — your local git is never touched.
+
+```bash
+remyxai outrider init --repo owner/name --auto-interest
+```
+
+This uses the **Remyx GitHub App** (`remyx-ai[bot]`) to:
+
+- Create a Research Interest from the repo (`--auto-interest`), or use an existing one (`--interest <uuid>`)
+- Write the Outrider workflow to the target repo and set its required Actions secrets
+- Open a bot-authored setup PR — and, in `auto` mode, merge it and fire the first run
+
+### Modes
+
+Set with `--mode` (default `auto`):
+
+- `auto` — provision, merge the setup PR, and start the first run
+- `review` — provision and open the setup PR for you to review and merge
+
+### Credentials
+
+**You set up two things, once:**
+
+1. Your `REMYXAI_API_KEY`, exported in your shell (see [Authenticate](#authenticate)) — this authorizes the CLI.
+2. A model provider connected on the [Integrations page](https://engine.remyx.ai/integrations) — Claude Code today, more providers coming soon. The Action needs this to call the model.
+
+**Remyx handles the rest.** You never create repo secrets by hand. During provisioning the Remyx GitHub App sets two Actions secrets on the target repo for you:
+
+| Repo secret | What it is |
+|---|---|
+| `REMYX_API_KEY` | A scoped automation key Remyx mints just for this repo — *not* your personal `REMYXAI_API_KEY`, and revocable on its own. |
+| `ANTHROPIC_API_KEY` (or your provider's key) | Copied from the provider you connected on the Integrations page, so the Action can call the model at runtime. |
+
+> **No provider connected yet?** As a one-time fallback, pass `--anthropic-key` (or set `ANTHROPIC_API_KEY`) and the CLI connects it for you. Otherwise no model key ever goes on the command line.
 
 If the Remyx GitHub App isn't installed on the target repo yet, the command surfaces the install link.
 
@@ -64,24 +142,15 @@ Run any command with `--help` for full flag listings and examples.
 | `remyxai papers refresh-status <task_id>` | Poll a refresh task |
 | `remyxai interests list` | List your Research Interests |
 | `remyxai interests get <name-or-uuid>` | Show one interest |
-| `remyxai interests create` | Create a new interest |
+| `remyxai interests create` | Create an interest from free-form context |
+| `remyxai interests from-repo <github-url>` | Create an interest from a GitHub repo profile |
+| `remyxai interests from-project <name-or-uuid>` | Create an interest from a project's experiments |
 | `remyxai interests update <id>` | Edit name / context / daily count / active state |
 | `remyxai interests toggle <id>` | Flip active/inactive |
 | `remyxai interests delete <id>` | Remove an interest |
 | `remyxai outrider init` | Install Outrider on a GitHub repo via the Remyx App |
 | `remyxai search list` | List recently added research assets (papers + Docker images) |
 | `remyxai search info <arxiv-id>` | Asset details |
-
-## Outrider install — what happens
-
-`remyxai outrider init` calls the Remyx engine, which uses the **Remyx GitHub App** (`remyx-ai[bot]`) to:
-
-- Write the Outrider workflow to the target repo
-- Set the workflow's required Actions secrets
-- Open a bot-authored setup PR (and merge it automatically in `--mode auto`)
-- Fire the first Outrider run
-
-Your local git is not touched. The only credential you provide is your `REMYXAI_API_KEY`, which authorizes the engine to act on your behalf through the App — it is not copied into the target repo's secrets. Anthropic and GitHub credentials needed at workflow runtime are configured by the App.
 
 ## Development
 
@@ -101,3 +170,4 @@ Releases: tag a `v*` release on GitHub and the `publish.yml` workflow builds + u
 - [Outrider](https://github.com/remyxai/outrider) — the GitHub Action this CLI installs
 - [engine.remyx.ai](https://engine.remyx.ai) — web app, account settings, API key
 - [Issues](https://github.com/remyxai/remyxai-cli/issues) — bug reports and feature requests
+```

--- a/remyxai/api/interests.py
+++ b/remyxai/api/interests.py
@@ -57,10 +57,26 @@ def get_interest(
 
 
 def create_interest(
-    name: str,
-    context: str,
+    name: Optional[str] = None,
+    context: Optional[str] = None,
     daily_count: int = 2,
     is_active: bool = True,
+    *,
+    # ── repo-sourced fields (from analyze_repo) ──────────────────────────
+    source_repo_url: Optional[str] = None,
+    source_repo_metadata: Optional[Any] = None,
+    repo_analysis: Optional[Any] = None,
+    generated_report: Optional[str] = None,
+    report_generated_at: Optional[str] = None,
+    # ── provisioning ("Automate paper PRs on this repo") ─────────────────
+    provision_action: Optional[bool] = None,
+    provision_auto_merge: Optional[bool] = None,
+    provision_repo_url: Optional[str] = None,
+    # ── project-sourced fields ───────────────────────────────────────────
+    project_id: Optional[str] = None,
+    mode: Optional[str] = None,
+    included_experiment_ids: Optional[List[str]] = None,
+    auto_update_from_experiments: Optional[bool] = None,
     api_key: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
@@ -72,18 +88,119 @@ def create_interest(
         name:        Short label, e.g. "RAG & Retrieval".
         context:     Natural language description of what to track.
                      Can also be a HuggingFace or GitHub URL — the server
-                     will scrape it and generate an embedding.
+                     will scrape it and generate an embedding. Optional for
+                     project-mode interests (the server fills a placeholder).
         daily_count: Items to surface per day (1–10, default 2).
         is_active:   Include in daily digest immediately (default True).
+
+    Repo-sourced kwargs (from a prior ``analyze_repo`` run): when
+    ``source_repo_url`` is set the server links the interest to its
+    canonical ExperimentHistory and dispatches experiment-history
+    extraction (response carries ``history_extraction_task_id``).
+
+    Provisioning kwargs map to the "Automate paper PRs on this repo"
+    choice. Leave ``provision_action`` unset/False for "Not now". Set it
+    True with ``provision_auto_merge=False`` to open a setup PR for review,
+    or ``True`` to set it up automatically (response carries
+    ``provision_task_id``).
+
+    Project-sourced kwargs: pass ``project_id`` (and optionally
+    ``mode='project_structured'``, ``included_experiment_ids``,
+    ``auto_update_from_experiments``) to build context from a project's
+    experiments. Response carries ``build_task_id``.
     """
+    payload: Dict[str, Any] = {
+        "daily_count": daily_count,
+        "is_active": is_active,
+    }
+    if name is not None:
+        payload["name"] = name
+    if context is not None:
+        payload["context"] = context
+
+    # Repo-sourced fields — only forwarded when present.
+    if source_repo_url is not None:
+        payload["source_repo_url"] = source_repo_url
+    if source_repo_metadata is not None:
+        payload["source_repo_metadata"] = source_repo_metadata
+    if repo_analysis is not None:
+        payload["repo_analysis"] = repo_analysis
+    if generated_report is not None:
+        payload["generated_report"] = generated_report
+    if report_generated_at is not None:
+        payload["report_generated_at"] = report_generated_at
+
+    # Provisioning — omitting provision_action entirely means "Not now".
+    if provision_action is not None:
+        payload["provision_action"] = provision_action
+    if provision_auto_merge is not None:
+        payload["provision_auto_merge"] = provision_auto_merge
+    if provision_repo_url is not None:
+        payload["provision_repo_url"] = provision_repo_url
+
+    # Project-sourced fields.
+    if project_id is not None:
+        payload["project_id"] = project_id
+    if mode is not None:
+        payload["mode"] = mode
+    if included_experiment_ids is not None:
+        payload["included_experiment_ids"] = included_experiment_ids
+    if auto_update_from_experiments is not None:
+        payload["auto_update_from_experiments"] = auto_update_from_experiments
+
     r = requests.post(
         f"{BASE_URL}/interests",
-        json={
-            "name": name,
-            "context": context,
-            "daily_count": daily_count,
-            "is_active": is_active,
-        },
+        json=payload,
+        headers=_h(api_key),
+        timeout=30,
+    )
+    log_api_response(r)
+    r.raise_for_status()
+    return r.json()
+
+
+# ─── Repo analysis (create-from-repo flow) ─────────────────────────────────
+
+def analyze_repo(
+    repo_url: str,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Kick off async analysis of a GitHub repo for a potential Research
+    Interest. The server clones/reads the repo and generates a profile
+    report (used as the interest context) plus structured repo_analysis.
+
+    Calls POST /api/v1.0/interests/analyze-repo
+
+    Returns 202 { task_id, status_url }. Poll with poll_analyze_repo.
+    """
+    r = requests.post(
+        f"{BASE_URL}/interests/analyze-repo",
+        json={"repo_url": repo_url},
+        headers=_h(api_key),
+        timeout=30,
+    )
+    log_api_response(r)
+    r.raise_for_status()
+    return r.json()
+
+
+def poll_analyze_repo(
+    task_id: str,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Poll a repo-analysis task.
+
+    Calls GET /api/v1.0/interests/analyze-repo/<task_id>
+
+    Returns the task dict { status, progress, message, result }. On
+    completion `result` carries:
+      { full_name, source_repo_url, source_repo_metadata,
+        report_markdown, repo_analysis, report_generated_at }
+    """
+    r = requests.get(
+        f"{BASE_URL}/interests/analyze-repo/{task_id}",
         headers=_h(api_key),
         timeout=30,
     )
@@ -166,7 +283,7 @@ def toggle_interest(
     return r.json()
 
 
-# ─── Outrider provisioning (REMYX-60) ──────────────────────────────────────
+# ─── Outrider provisioning  ──────────────────────────────────────
 
 def provision_action(
     interest_id: str,

--- a/remyxai/api/projects.py
+++ b/remyxai/api/projects.py
@@ -1,0 +1,71 @@
+"""
+remyxai/api/projects.py
+
+Client calls for the Projects API.
+Wraps /api/v1.0/projects/* and /api/v1.0/experiments in
+engine/app/api/projects.py and engine/app/api/experiments.py.
+
+Used by the create-research-interest-from-a-project flow: list the
+caller's projects to pick a project_id, and optionally list a project's
+experiments to curate `included_experiment_ids`.
+"""
+from __future__ import annotations
+
+import logging
+import requests
+from typing import Any, Dict, List, Optional
+
+from . import BASE_URL, HEADERS, get_headers, log_api_response
+
+logger = logging.getLogger(__name__)
+
+
+def _h(api_key: Optional[str] = None) -> dict:
+    return get_headers(api_key) if api_key else HEADERS
+
+
+def list_projects(api_key: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    List non-archived projects for the caller's team.
+
+    Calls GET /api/v1.0/projects
+
+    Returns list of:
+      { id, name, description, team_id, is_archived, config,
+        scope_context, created_at, updated_at }
+    """
+    r = requests.get(f"{BASE_URL}/projects", headers=_h(api_key), timeout=30)
+    log_api_response(r)
+    r.raise_for_status()
+    return r.json().get("projects", [])
+
+
+def list_experiments(
+    project_id: Optional[str] = None,
+    limit: int = 100,
+    api_key: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    List experiments, optionally scoped to a project.
+
+    Calls GET /api/v1.0/experiments[?project_id=<id>&limit=<n>]
+
+    Returns a list of experiment dicts (id, name, project_id, ...).
+    The server caps `limit` at 100.
+    """
+    params: Dict[str, Any] = {"limit": limit}
+    if project_id:
+        params["project_id"] = project_id
+    r = requests.get(
+        f"{BASE_URL}/experiments",
+        headers=_h(api_key),
+        params=params,
+        timeout=30,
+    )
+    log_api_response(r)
+    r.raise_for_status()
+    body = r.json()
+    # The experiments endpoint returns either a bare list or an envelope.
+    if isinstance(body, dict):
+        return body.get("experiments", body.get("results", []))
+    return body

--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -18,6 +18,8 @@ from remyxai.cli.interest_actions import (
     handle_interests_list,
     handle_interests_get,
     handle_interests_create,
+    handle_interests_create_from_repo,
+    handle_interests_create_from_project,
     handle_interests_update,
     handle_interests_delete,
     handle_interests_toggle,
@@ -323,13 +325,20 @@ def interests_get(interest, output_format):
               help="Recommendations per day (1-10).")
 @click.option("--inactive", is_flag=True, default=False,
               help="Create as inactive (excluded from daily digest until toggled).")
+@click.option("--refresh/--no-refresh", default=True, show_default=True,
+              help="Kick off a recommendations refresh after creation.")
+@click.option("--wait", "-w", is_flag=True, default=False,
+              help="Block until the recommendations refresh completes.")
 @click.option("--format", "-f", "output_format", default="text",
               type=click.Choice(["text", "json"]), show_default=True)
-def interests_create(name, context, daily_count, inactive, output_format):
+def interests_create(name, context, daily_count, inactive, refresh, wait,
+                     output_format):
     """
     Create a new Research Interest profile.
 
-    Prompts interactively if --name or --context are not supplied.
+    Prompts interactively if --name or --context are not supplied. By
+    default it also kicks off a recommendations refresh so the interest is
+    populated; pass --no-refresh to skip, or --wait to block until ready.
 
     Examples:
 
@@ -338,13 +347,119 @@ def interests_create(name, context, daily_count, inactive, output_format):
       remyxai interests create \\
         --name "LLM Efficiency" \\
         --context "Quantization, speculative decoding, KV cache compression" \\
-        --daily-count 3
+        --daily-count 3 --wait
     """
     handle_interests_create(
         name=name,
         context=context,
         daily_count=daily_count,
         inactive=inactive,
+        refresh=refresh,
+        wait=wait,
+        output_format=output_format,
+    )
+
+
+@interests.command("from-repo")
+@click.argument("repo_url")
+@click.option("--name", "-n", default=None,
+              help="Interest name (defaults to the repo name).")
+@click.option("--daily-count", "-d", default=2, show_default=True,
+              help="Recommendations per day (1-10).")
+@click.option("--inactive", is_flag=True, default=False,
+              help="Create as inactive (excluded from daily digest until toggled).")
+@click.option("--automate", default="none", show_default=True,
+              type=click.Choice(["none", "review", "auto"]),
+              help="Automate paper PRs on this repo: 'none' (Not now), "
+                   "'review' (open a setup PR to review), or "
+                   "'auto' (set it up + merge + first run).")
+@click.option("--timeout", default=300, show_default=True,
+              help="Seconds to wait for repo analysis before giving up.")
+@click.option("--refresh/--no-refresh", default=True, show_default=True,
+              help="Kick off a recommendations refresh after creation.")
+@click.option("--wait", "-w", is_flag=True, default=False,
+              help="Block until the recommendations refresh completes.")
+@click.option("--format", "-f", "output_format", default="text",
+              type=click.Choice(["text", "json"]), show_default=True)
+def interests_from_repo(repo_url, name, daily_count, inactive, automate,
+                        timeout, refresh, wait, output_format):
+    """
+    Create a Research Interest from a GitHub repo.
+
+    Analyzes REPO_URL to generate a profile, then creates the interest
+    linked to the repo — which dispatches experiment-history extraction.
+    Paper-PR automation defaults to "Not now"; opt in with --automate.
+    A recommendations refresh is kicked off by default (--no-refresh to
+    skip, --wait to block until ready).
+
+    Examples:
+
+      remyxai interests from-repo https://github.com/remyxai/outrider
+
+      remyxai interests from-repo https://github.com/remyxai/outrider \\
+        --name "Outrider" --daily-count 3 --automate review --wait
+    """
+    handle_interests_create_from_repo(
+        repo_url=repo_url,
+        name=name,
+        daily_count=daily_count,
+        inactive=inactive,
+        automate=automate,
+        timeout=timeout,
+        refresh=refresh,
+        wait=wait,
+        output_format=output_format,
+    )
+
+
+@interests.command("from-project")
+@click.argument("project")
+@click.option("--name", "-n", default=None,
+              help="Interest name (defaults to a project-derived name).")
+@click.option("--daily-count", "-d", default=2, show_default=True,
+              help="Recommendations per day (1-10).")
+@click.option("--inactive", is_flag=True, default=False,
+              help="Create as inactive (excluded from daily digest until toggled).")
+@click.option("--include-experiment", "-e", multiple=True,
+              help="Experiment name or UUID to track (repeatable). "
+                   "Omit to track all experiments on the project.")
+@click.option("--no-auto-update", is_flag=True, default=False,
+              help="Do not auto-refresh context as new experiments land.")
+@click.option("--refresh/--no-refresh", default=True, show_default=True,
+              help="Kick off a recommendations refresh after creation.")
+@click.option("--wait", "-w", is_flag=True, default=False,
+              help="Block until context build + recommendations refresh complete "
+                   "(recommended for project interests).")
+@click.option("--format", "-f", "output_format", default="text",
+              type=click.Choice(["text", "json"]), show_default=True)
+def interests_from_project(project, name, daily_count, inactive,
+                           include_experiment, no_auto_update, refresh, wait,
+                           output_format):
+    """
+    Create a Research Interest from a project.
+
+    PROJECT is a project name or UUID. The server builds the interest
+    context from the project's experiments. By default it tracks every
+    experiment and keeps the context fresh as new ones are added. A
+    recommendations refresh is kicked off by default — use --wait so it
+    runs after the async context build finishes.
+
+    Examples:
+
+      remyxai interests from-project "Spatial VQA" --wait
+
+      remyxai interests from-project 1a2b3c4d-... \\
+        -e "baseline-run" -e "dpo-v2" --no-auto-update
+    """
+    handle_interests_create_from_project(
+        project=project,
+        name=name,
+        daily_count=daily_count,
+        inactive=inactive,
+        include_experiment=include_experiment,
+        no_auto_update=no_auto_update,
+        refresh=refresh,
+        wait=wait,
         output_format=output_format,
     )
 

--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -610,17 +610,16 @@ def outrider_init(
     and no personal `gh` token is needed; only your REMYXAI_API_KEY.
 
     Requires: the Remyx GitHub App installed on the repo (the command
-    surfaces the install link if it isn't) and a connected model provider
-    (pass --anthropic-key or set ANTHROPIC_API_KEY the first time).
+    surfaces the install link if it isn't) and a connected model provider —
+    connect Claude Code once on engine.remyx.ai/integrations and the CLI
+    uses it automatically. (--anthropic-key / ANTHROPIC_API_KEY is only a
+    one-time fallback if you haven't connected one there yet.)
 
     Examples:
 
       remyxai outrider init --repo remyxai/RepoRanger --auto-interest
 
       remyxai outrider init --repo owner/name --interest <uuid> --mode review
-
-      REMYXAI_API_KEY=... ANTHROPIC_API_KEY=... \\
-        remyxai outrider init --repo owner/name --interest <uuid> --yes
     """
     handle_outrider_init(
         repo=repo,

--- a/remyxai/cli/interest_actions.py
+++ b/remyxai/cli/interest_actions.py
@@ -8,17 +8,30 @@ import json
 import re
 import sys
 import textwrap
-from typing import Optional
+import time
+from typing import List, Optional
 
 import click
 
 from remyxai.api.interests import (
+    analyze_repo,
     create_interest,
     delete_interest,
     get_interest,
     list_interests,
+    poll_analyze_repo,
     toggle_interest,
     update_interest,
+)
+from remyxai.api.projects import list_experiments, list_projects
+from remyxai.api.recommendations import (
+    poll_refresh_task,
+    trigger_recommendations_refresh,
+)
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
 )
 
 
@@ -43,6 +56,109 @@ def _print_interest(i: dict, verbose: bool = False) -> None:
                 subsequent_indent="                   ",
             )
             click.echo(wrapped)
+
+
+# ─── recommendations auto-refresh ────────────────────────────────────────────
+
+_REFRESH_TERMINAL = {"completed", "failed"}
+
+
+def _poll_task(
+    task_id: str,
+    timeout: int = 600,
+    poll_interval: int = 4,
+    api_key: Optional[str] = None,
+) -> Optional[dict]:
+    """Poll any background task to a terminal state via the shared
+    refresh-poll endpoint (build, extraction, and refresh tasks all live in
+    the same task store). Returns the final task dict, or None on
+    timeout/error."""
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            task = poll_refresh_task(task_id, api_key=api_key)
+        except Exception:
+            return None
+        if (task.get("status") or "").lower() in _REFRESH_TERMINAL:
+            return task
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(poll_interval)
+
+
+def _kick_off_recommendations(
+    interest_id: str,
+    *,
+    num_results: Optional[int] = None,
+    wait: bool = False,
+    await_task_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    echo=None,
+) -> Optional[dict]:
+    """Trigger a recommendations refresh for a freshly-created interest so it
+    has actual recommendations.
+
+    ``await_task_id`` (project-mode context build) is polled to completion
+    first when ``wait`` is set, so recommendations rank against the built
+    context rather than the placeholder. ``echo`` is an optional
+    callable(str) for progress lines (text mode). Returns the refresh
+    trigger response, or None if it could not be started.
+    """
+    def _say(msg: str) -> None:
+        if echo:
+            echo(msg)
+
+    # Project-mode interests build their context asynchronously; let that
+    # finish before generating recommendations.
+    if wait and await_task_id:
+        _say("  ⏳ waiting for interest context to finish building…")
+        built = _poll_task(await_task_id, api_key=api_key)
+        if built and (built.get("status") or "").lower() == "failed":
+            _say(
+                "  ⚠️  context build failed "
+                f"({built.get('error') or 'unknown error'}); "
+                "recommendations may be weak."
+            )
+
+    try:
+        res = trigger_recommendations_refresh(
+            interest_id=interest_id,
+            num_results=num_results,
+            api_key=api_key,
+        )
+    except Exception as e:
+        _say(f"  ⚠️  could not start recommendations refresh: {e}")
+        return None
+
+    tasks = res.get("tasks", [])
+    if not tasks:
+        _say("  ⚠️  recommendations refresh returned no tasks.")
+        return res
+
+    for t in tasks:
+        _say(f"  🔄 recommendations refresh started (task: {t.get('task_id')})")
+
+    if not wait:
+        _say("     Track with:  remyxai papers refresh-status <task_id>")
+        return res
+
+    _say("  ⏳ generating recommendations…")
+    for t in tasks:
+        final = _poll_task(t.get("task_id"), api_key=api_key)
+        if not final:
+            _say("  ⚠️  timed out waiting for recommendations.")
+            continue
+        status = (final.get("status") or "").lower()
+        if status == "completed":
+            count = (final.get("result") or {}).get("count")
+            label = f"{count} recommendation(s)" if count is not None else "recommendations"
+            _say(f"  ✅ {label} ready.")
+        else:
+            _say(
+                "  ❌ recommendations refresh failed: "
+                f"{final.get('error') or final.get('message') or 'unknown error'}"
+            )
+    return res
 
 
 # ─── name-or-id resolver ─────────────────────────────────────────────────────
@@ -139,6 +255,8 @@ def handle_interests_create(
     daily_count: int,
     inactive: bool,
     output_format: str,
+    refresh: bool = True,
+    wait: bool = False,
 ) -> None:
     if not name:
         name = click.prompt("  Interest name (e.g. 'RAG & Retrieval')")
@@ -163,19 +281,33 @@ def handle_interests_create(
         click.echo(f"❌ Failed to create interest: {e}", err=True)
         sys.exit(1)
 
+    # Populate the interest with actual recommendations.
+    refresh_res = None
+    if refresh:
+        refresh_res = _kick_off_recommendations(
+            result["id"],
+            num_results=daily_count,
+            wait=wait,
+            echo=(None if output_format == "json" else click.echo),
+        )
+
     if output_format == "json":
+        if refresh_res is not None:
+            result["recommendation_refresh"] = refresh_res
         click.echo(json.dumps(result, indent=2))
         return
 
     click.echo(f"\n✅  Created '{result['name']}'  (id: {result['id']})")
     click.echo(
         f"   daily_count: {result['daily_count']}  |  "
-        f"active: {result['is_active']}\n"
+        f"active: {result['is_active']}"
     )
-    click.echo(
-        "  Trigger your first recommendations:\n"
-        f"  remyxai papers refresh --interest {result['name']!r} --wait\n"
-    )
+    if not refresh:
+        click.echo(
+            "\n  Trigger your first recommendations:\n"
+            f"  remyxai papers refresh --interest {result['name']!r} --wait"
+        )
+    click.echo()
 
 
 # ─── update ──────────────────────────────────────────────────────────────────
@@ -272,3 +404,361 @@ def handle_interests_toggle(interest_id: str, output_format: str) -> None:
 
     state = "active ✅" if result.get("is_active") else "paused ⏸"
     click.echo(f"\n  '{result['name']}' is now {state}\n")
+
+
+# ─── create from repo ──────────────────────────────────────────────────────
+
+# "Automate paper PRs on this repo" choices → provisioning kwargs.
+#   none   → "Not now"                  (no provisioning)
+#   review → "Open a PR for me to review" (setup PR, no auto-merge)
+#   auto   → "Set it up for me"            (setup PR + auto-merge + first run)
+AUTOMATE_CHOICES = ("none", "review", "auto")
+
+
+class RepoAnalysisError(RuntimeError):
+    """Raised when repo analysis fails, times out, or returns no report."""
+
+
+def _run_repo_analysis(
+    repo_url: str,
+    timeout: int = 300,
+    poll_interval: int = 5,
+    api_key: Optional[str] = None,
+    echo=None,
+) -> dict:
+    """Kick off analyze-repo and poll to completion.
+
+    Returns the completed task's ``result`` dict (report_markdown,
+    source_repo_url, repo_analysis, …). ``echo`` is an optional
+    callable(str) for progress lines. Raises RepoAnalysisError on
+    failure, timeout, or a completed-but-empty report.
+    """
+    started = analyze_repo(repo_url, api_key=api_key)
+    task_id = started.get("task_id")
+    if not task_id:
+        raise RepoAnalysisError(f"analyze-repo returned no task_id: {started}")
+
+    deadline = time.monotonic() + timeout
+    last_message = None
+
+    while True:
+        task = poll_analyze_repo(task_id, api_key=api_key)
+        status = (task.get("status") or "").lower()
+
+        message = task.get("message")
+        if echo and message and message != last_message:
+            pct = task.get("progress")
+            prefix = f"  [{pct}%] " if pct is not None else "  "
+            echo(f"{prefix}{message}")
+            last_message = message
+
+        if status == "completed":
+            result = task.get("result") or {}
+            if not result.get("report_markdown"):
+                raise RepoAnalysisError(
+                    f"analysis completed but returned no report: {result}"
+                )
+            return result
+
+        if status == "failed":
+            err = task.get("error") or task.get("message") or "unknown error"
+            raise RepoAnalysisError(f"repo analysis failed: {err}")
+
+        if time.monotonic() >= deadline:
+            raise RepoAnalysisError(
+                f"repo analysis timed out after {timeout}s "
+                f"(analyze-repo task {task_id})"
+            )
+
+        time.sleep(poll_interval)
+
+
+def create_interest_from_repo(
+    repo_url: str,
+    *,
+    name: Optional[str] = None,
+    daily_count: int = 2,
+    is_active: bool = True,
+    automate: str = "none",
+    timeout: int = 300,
+    poll_interval: int = 5,
+    api_key: Optional[str] = None,
+    echo=None,
+) -> dict:
+    """Analyze a GitHub repo and create a Research Interest from it.
+
+    This is the shared core behind ``interests from-repo`` and
+    ``outrider init --auto-interest``: it generates the repo profile
+    report (used as the rich interest context) and carries the repo
+    fields so the server links the interest to its ExperimentHistory and
+    dispatches experiment-history extraction.
+
+    Returns the created interest dict. Raises RepoAnalysisError on
+    analysis problems (caller decides how to surface it); ``create_interest``
+    network errors propagate as-is.
+
+    ``automate`` controls the "Automate paper PRs on this repo" option:
+    "none" (Not now), "review" (setup PR), or "auto" (PR + merge + run).
+    """
+    if automate not in AUTOMATE_CHOICES:
+        raise ValueError(f"automate must be one of {AUTOMATE_CHOICES}")
+
+    result = _run_repo_analysis(
+        repo_url,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        api_key=api_key,
+        echo=echo,
+    )
+    report = result["report_markdown"]
+    source_repo_url = result.get("source_repo_url") or repo_url
+
+    provision_kwargs: dict = {}
+    if automate in ("review", "auto"):
+        provision_kwargs = {
+            "provision_action": True,
+            "provision_auto_merge": (automate == "auto"),
+            "provision_repo_url": source_repo_url,
+        }
+
+    interest_name = name or (result.get("full_name") or repo_url).split("/")[-1]
+
+    return create_interest(
+        name=interest_name,
+        context=report,
+        daily_count=daily_count,
+        is_active=is_active,
+        source_repo_url=source_repo_url,
+        source_repo_metadata=result.get("source_repo_metadata"),
+        repo_analysis=result.get("repo_analysis"),
+        generated_report=report,
+        report_generated_at=result.get("report_generated_at"),
+        api_key=api_key,
+        **provision_kwargs,
+    )
+
+
+def handle_interests_create_from_repo(
+    repo_url: str,
+    name: Optional[str],
+    daily_count: int,
+    inactive: bool,
+    automate: str,
+    timeout: int,
+    output_format: str,
+    refresh: bool = True,
+    wait: bool = False,
+) -> None:
+    """Create a Research Interest from a GitHub repo (CLI handler).
+
+    Thin wrapper over ``create_interest_from_repo`` that handles progress
+    output, error reporting, and result formatting.
+    """
+    if automate not in AUTOMATE_CHOICES:
+        click.echo(
+            f"❌ --automate must be one of {', '.join(AUTOMATE_CHOICES)}",
+            err=True,
+        )
+        sys.exit(1)
+
+    if output_format != "json":
+        click.echo(f"\n🔍  Analyzing {repo_url} … (this can take 30–90s)")
+
+    try:
+        created = create_interest_from_repo(
+            repo_url,
+            name=name,
+            daily_count=daily_count,
+            is_active=not inactive,
+            automate=automate,
+            timeout=timeout,
+            echo=(None if output_format == "json" else click.echo),
+        )
+    except RepoAnalysisError as e:
+        click.echo(f"\n❌ {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"❌ Failed to create interest: {e}", err=True)
+        sys.exit(1)
+
+    source_repo_url = created.get("source_repo_url") or repo_url
+
+    # The repo profile is already the interest's context, so recommendations
+    # can be generated immediately (no need to await the deeper extraction).
+    refresh_res = None
+    if refresh:
+        refresh_res = _kick_off_recommendations(
+            created["id"],
+            num_results=daily_count,
+            wait=wait,
+            echo=(None if output_format == "json" else click.echo),
+        )
+
+    if output_format == "json":
+        if refresh_res is not None:
+            created["recommendation_refresh"] = refresh_res
+        click.echo(json.dumps(created, indent=2))
+        return
+
+    click.echo(f"\n✅  Created '{created['name']}'  (id: {created['id']})")
+    click.echo(f"       source repo: {source_repo_url}")
+    click.echo(
+        f"       daily_count: {created.get('daily_count')}  |  "
+        f"active: {created.get('is_active')}"
+    )
+    if created.get("history_extraction_task_id"):
+        click.echo(
+            "       🧪 experiment-history extraction dispatched "
+            f"(task: {created['history_extraction_task_id']})"
+        )
+    if created.get("provision_task_id"):
+        mode_label = (
+            "auto-merge + first run" if automate == "auto" else "setup PR for review"
+        )
+        click.echo(
+            f"       🤖 paper-PR automation provisioning ({mode_label}) "
+            f"(task: {created['provision_task_id']})"
+        )
+    else:
+        click.echo("       paper-PR automation: not now")
+    click.echo()
+
+
+# ─── create from project ───────────────────────────────────────────────────
+
+def _resolve_project_id(name_or_id: str) -> str:
+    """Accept a project UUID or name and return the UUID."""
+    if UUID_RE.match(name_or_id):
+        return name_or_id
+
+    try:
+        projects = list_projects()
+    except Exception as e:
+        click.echo(f"❌ Failed to fetch projects: {e}", err=True)
+        sys.exit(1)
+
+    needle = name_or_id.lower()
+    for p in projects:
+        if (p.get("name") or "").lower() == needle:
+            return p["id"]
+
+    names = [p.get("name", "") for p in projects]
+    available = ", ".join(n for n in names if n) or "none"
+    click.echo(
+        f"No project found with name {name_or_id!r}. Available: {available}",
+        err=True,
+    )
+    sys.exit(1)
+
+
+def _resolve_experiment_ids(
+    project_id: str,
+    selectors: List[str],
+) -> List[str]:
+    """Map experiment names-or-UUIDs to UUIDs within a project."""
+    resolved: List[str] = []
+    experiments = None
+    by_name = None
+
+    for sel in selectors:
+        if UUID_RE.match(sel):
+            resolved.append(sel)
+            continue
+        # Lazy-load the project's experiments only when a name is given.
+        if experiments is None:
+            try:
+                experiments = list_experiments(project_id=project_id)
+            except Exception as e:
+                click.echo(f"❌ Failed to fetch experiments: {e}", err=True)
+                sys.exit(1)
+            by_name = {
+                (e.get("name") or "").lower(): e["id"] for e in experiments
+            }
+        match = by_name.get(sel.lower())
+        if not match:
+            click.echo(
+                f"No experiment named {sel!r} in this project.", err=True
+            )
+            sys.exit(1)
+        resolved.append(match)
+    return resolved
+
+
+def handle_interests_create_from_project(
+    project: str,
+    name: Optional[str],
+    daily_count: int,
+    inactive: bool,
+    include_experiment: tuple,
+    no_auto_update: bool,
+    output_format: str,
+    refresh: bool = True,
+    wait: bool = False,
+) -> None:
+    """Create a project-structured Research Interest.
+
+    The server builds the interest context from the project's experiments
+    (asynchronously) and returns a ``build_task_id``. By default it tracks
+    all experiments on the project and auto-updates as new ones land; pass
+    ``include_experiment`` to curate a subset.
+    """
+    project_id = _resolve_project_id(project)
+
+    included_ids = None
+    if include_experiment:
+        included_ids = _resolve_experiment_ids(project_id, list(include_experiment))
+
+    try:
+        created = create_interest(
+            name=name,
+            daily_count=daily_count,
+            is_active=not inactive,
+            project_id=project_id,
+            mode="project_structured",
+            included_experiment_ids=included_ids,
+            auto_update_from_experiments=(False if no_auto_update else None),
+        )
+    except Exception as e:
+        click.echo(f"❌ Failed to create interest: {e}", err=True)
+        sys.exit(1)
+
+    # Project-mode context is built asynchronously (build_task_id). Pass it
+    # as await_task_id so a --wait refresh sequences behind the build and
+    # recommendations rank against the real context, not the placeholder.
+    refresh_res = None
+    if refresh:
+        refresh_res = _kick_off_recommendations(
+            created["id"],
+            num_results=daily_count,
+            wait=wait,
+            await_task_id=created.get("build_task_id"),
+            echo=(None if output_format == "json" else click.echo),
+        )
+
+    if output_format == "json":
+        if refresh_res is not None:
+            created["recommendation_refresh"] = refresh_res
+        click.echo(json.dumps(created, indent=2))
+        return
+
+    click.echo(f"\n✅  Created '{created['name']}'  (id: {created['id']})")
+    click.echo(f"       project: {project_id}")
+    if included_ids:
+        click.echo(f"       tracking {len(included_ids)} selected experiment(s)")
+    else:
+        click.echo("       tracking: all experiments on the project")
+    click.echo(
+        f"       daily_count: {created.get('daily_count')}  |  "
+        f"active: {created.get('is_active')}"
+    )
+    if created.get("build_task_id"):
+        click.echo(
+            "       ⏳ building recommendation context from experiments "
+            f"(task: {created['build_task_id']})"
+        )
+    if refresh and not wait:
+        click.echo(
+            "\n  ℹ️  For project interests, run the refresh with --wait so "
+            "recommendations\n      generate after the context finishes building."
+        )
+    click.echo()

--- a/remyxai/cli/outrider_actions.py
+++ b/remyxai/cli/outrider_actions.py
@@ -29,10 +29,14 @@ from typing import Optional
 import click
 
 from remyxai.api.interests import (
-    create_interest,
     get_interest,
     provision_action,
     poll_provision_action,
+)
+from remyxai.cli.interest_actions import (
+    RepoAnalysisError,
+    create_interest_from_repo,
+    _kick_off_recommendations,
 )
 from remyxai.api.integrations import connect_credential, get_integration_status
 from remyxai.api.github_app import get_app_install_url, is_app_installed
@@ -107,13 +111,26 @@ def _resolve_interest_id(interest_id, auto_interest, repo, repo_url, api_key):
         click.echo(
             "Creating a Research Interest from this repo (may take 30-90s)…"
         )
+        # Use the analyze-repo flow so the interest gets a rich,
+        # ExperimentHistory-derived context (and the server dispatches
+        # extraction) instead of a URL-only stub. Paper-PR
+        # provisioning is handled separately below by `outrider init`,
+        # so we don't provision here (automate="none").
         try:
-            created = create_interest(
+            created = create_interest_from_repo(
+                repo_url,
                 name=repo.split("/")[-1],
-                context=repo_url,
                 daily_count=3,
                 is_active=True,
+                automate="none",
                 api_key=api_key,
+                echo=click.echo,
+            )
+        except RepoAnalysisError as e:
+            raise click.ClickException(
+                f"interest creation failed during repo analysis: {e}\n"
+                f"  Try again, or create one at engine.remyx.ai and re-run "
+                f"with --interest <uuid>."
             )
         except Exception as e:
             raise click.ClickException(
@@ -127,6 +144,11 @@ def _resolve_interest_id(interest_id, auto_interest, repo, repo_url, api_key):
                 f"interest creation did not return a UUID: {created}"
             )
         click.echo(f"✓ Created interest: {new_id}")
+        if created.get("history_extraction_task_id"):
+            click.echo(
+                "  🧪 experiment-history extraction dispatched; "
+                "interest context will keep deepening as it completes."
+            )
         return new_id
 
     typed = click.prompt("Remyx interest UUID (from engine.remyx.ai)").strip()
@@ -308,6 +330,19 @@ def handle_outrider_init(
     # 6. Preflight: App install + model provider (only needed to provision)
     _ensure_app_installed(resolved_repo, api_key, no_wait)
     _ensure_model_provider(anthropic_key, api_key)
+
+    # 6b. Pre-warm recommendations so the first run has picks to open a PR
+    # from. A brand-new interest ranks asynchronously; firing the Outrider
+    # first run before the pool populates makes it report "no recommendations"
+    # (the cold-start race). Trigger a refresh now and — unless --no-wait —
+    # block until the pool is populated before provisioning dispatches the run.
+    click.echo("\nWarming up recommendations for the interest…")
+    _kick_off_recommendations(
+        resolved_interest,
+        wait=(not no_wait),
+        api_key=api_key,
+        echo=click.echo,
+    )
 
     # 7. Provision (server-side, bot-authored)
     auto_merge = (mode == "auto")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="remyxai",
-    version="0.2.7",
+    version="0.3.0",
     packages=find_packages(include=["remyxai", "remyxai.*"]),
     install_requires=[
         "click",

--- a/tests/cli/test_interests_actions.py
+++ b/tests/cli/test_interests_actions.py
@@ -1,0 +1,284 @@
+"""Tests for the `interests from-repo` and `interests from-project` commands.
+
+These exercise the CLI wiring + action handlers with the API client layer
+mocked, so no network calls are made. The handlers import the API
+functions into the ``interest_actions`` namespace, so we patch them there.
+"""
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from remyxai.cli import interest_actions
+from remyxai.cli.commands import cli
+
+
+# ─── shared fixtures-as-constants ──────────────────────────────────────────
+
+ANALYSIS_RESULT = {
+    "full_name": "remyxai/outrider",
+    "source_repo_url": "https://github.com/remyxai/outrider",
+    "source_repo_metadata": {"stars": 7},
+    "report_markdown": "# Research Interest Profile: outrider\n\nblah blah",
+    "repo_analysis": {"themes": ["agents"]},
+    "report_generated_at": "2026-06-10T03:41:19.699514",
+}
+
+CREATED_FROM_REPO = {
+    "id": "29ca03e7-454d-446c-9941-32c96c53d95d",
+    "name": "outrider",
+    "daily_count": 3,
+    "is_active": True,
+    "source_repo_url": "https://github.com/remyxai/outrider",
+    "history_extraction_task_id": "df9c4bd8-2d52-4917-9112-5de66718111e",
+}
+
+REFRESH_RESPONSE = {
+    "tasks": [{"task_id": "refresh-1", "interest_name": "outrider",
+               "status": "pending"}],
+}
+
+
+@contextmanager
+def _refresh_patch():
+    """Patch the recommendations refresh trigger (called by default after
+    every create). Yields the mock so callers can assert on it."""
+    with patch.object(interest_actions, "trigger_recommendations_refresh",
+                      return_value=REFRESH_RESPONSE) as m:
+        yield m
+
+
+@contextmanager
+def _repo_mocks(create_return=None):
+    """Patch the three repo-flow API calls + the refresh trigger."""
+    create_return = create_return or CREATED_FROM_REPO
+    with patch.object(interest_actions, "analyze_repo",
+                      return_value={"task_id": "task-123"}) as analyze, \
+         patch.object(interest_actions, "poll_analyze_repo",
+                      return_value={"status": "completed", "progress": 100,
+                                    "result": ANALYSIS_RESULT}) as poll, \
+         patch.object(interest_actions, "create_interest",
+                      return_value=create_return) as create, \
+         _refresh_patch() as refresh:
+        yield analyze, poll, create, refresh
+
+
+# ─── from-repo ──────────────────────────────────────────────────────────────
+
+def test_from_repo_default_no_provisioning_and_refreshes():
+    with _repo_mocks() as (analyze, poll, create, refresh):
+        result = CliRunner().invoke(
+            cli, ["interests", "from-repo",
+                  "https://github.com/remyxai/outrider"],
+        )
+
+    assert result.exit_code == 0, result.output
+    analyze.assert_called_once_with(
+        "https://github.com/remyxai/outrider", api_key=None
+    )
+
+    kwargs = create.call_args.kwargs
+    # Repo fields forwarded so the server triggers history extraction.
+    assert kwargs["source_repo_url"] == "https://github.com/remyxai/outrider"
+    assert kwargs["generated_report"] == ANALYSIS_RESULT["report_markdown"]
+    assert kwargs["repo_analysis"] == ANALYSIS_RESULT["repo_analysis"]
+    # "Not now" → no provisioning kwargs at all.
+    assert "provision_action" not in kwargs
+    assert "extraction dispatched" in result.output
+    assert "paper-PR automation: not now" in result.output
+    # Recommendations refresh kicked off for the new interest by default.
+    refresh.assert_called_once()
+    assert refresh.call_args.kwargs["interest_id"] == CREATED_FROM_REPO["id"]
+    assert "recommendations refresh started" in result.output
+
+
+def test_from_repo_no_refresh_skips_trigger():
+    with _repo_mocks() as (analyze, poll, create, refresh):
+        result = CliRunner().invoke(
+            cli, ["interests", "from-repo",
+                  "https://github.com/remyxai/outrider", "--no-refresh"],
+        )
+    assert result.exit_code == 0, result.output
+    refresh.assert_not_called()
+
+
+def test_from_repo_automate_auto():
+    with _repo_mocks(
+        create_return={**CREATED_FROM_REPO, "provision_task_id": "prov-1"},
+    ) as (analyze, poll, create, refresh):
+        result = CliRunner().invoke(
+            cli, ["interests", "from-repo",
+                  "https://github.com/remyxai/outrider", "--automate", "auto"],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = create.call_args.kwargs
+    assert kwargs["provision_action"] is True
+    assert kwargs["provision_auto_merge"] is True
+    assert kwargs["provision_repo_url"] == "https://github.com/remyxai/outrider"
+
+
+def test_from_repo_automate_review_no_auto_merge():
+    with _repo_mocks(
+        create_return={**CREATED_FROM_REPO, "provision_task_id": "prov-2"},
+    ) as (analyze, poll, create, refresh):
+        result = CliRunner().invoke(
+            cli, ["interests", "from-repo",
+                  "https://github.com/remyxai/outrider", "--automate", "review"],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = create.call_args.kwargs
+    assert kwargs["provision_action"] is True
+    assert kwargs["provision_auto_merge"] is False
+
+
+def test_from_repo_analysis_failure_exits_nonzero():
+    analyze = patch.object(interest_actions, "analyze_repo",
+                           return_value={"task_id": "task-x"})
+    poll = patch.object(interest_actions, "poll_analyze_repo",
+                        return_value={"status": "failed", "error": "boom"})
+    with analyze, poll:
+        result = CliRunner().invoke(
+            cli, ["interests", "from-repo", "https://github.com/x/y"],
+        )
+    assert result.exit_code != 0
+    assert "failed" in result.output.lower()
+
+
+def test_from_repo_custom_name_overrides_repo_name():
+    with _repo_mocks() as (analyze, poll, create, refresh):
+        CliRunner().invoke(
+            cli, ["interests", "from-repo", "https://github.com/remyxai/outrider",
+                  "--name", "My Interest", "--daily-count", "5"],
+        )
+    kwargs = create.call_args.kwargs
+    assert kwargs["name"] == "My Interest"
+    assert kwargs["daily_count"] == 5
+
+
+# ─── from-project ─────────────────────────────────────────────────────────
+
+PROJECTS = [
+    {"id": "11111111-1111-1111-1111-111111111111", "name": "Spatial VQA"},
+    {"id": "22222222-2222-2222-2222-222222222222", "name": "RAG"},
+]
+
+CREATED_FROM_PROJECT = {
+    "id": "33333333-3333-3333-3333-333333333333",
+    "name": "Spatial VQA recs",
+    "daily_count": 2,
+    "is_active": True,
+    "build_task_id": "build-9",
+}
+
+
+def test_from_project_resolves_name_and_sets_project_mode():
+    lp = patch.object(interest_actions, "list_projects", return_value=PROJECTS)
+    create = patch.object(interest_actions, "create_interest",
+                          return_value=CREATED_FROM_PROJECT)
+    with lp, create as c, _refresh_patch() as refresh:
+        result = CliRunner().invoke(
+            cli, ["interests", "from-project", "Spatial VQA"],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = c.call_args.kwargs
+    assert kwargs["project_id"] == PROJECTS[0]["id"]
+    assert kwargs["mode"] == "project_structured"
+    assert kwargs["included_experiment_ids"] is None
+    assert "building recommendation context" in result.output
+    assert "all experiments" in result.output
+    # Refresh kicked off for the project interest.
+    refresh.assert_called_once()
+    assert refresh.call_args.kwargs["interest_id"] == CREATED_FROM_PROJECT["id"]
+
+
+def test_from_project_wait_sequences_build_then_refresh():
+    """--wait should poll the build task before the recs are usable."""
+    lp = patch.object(interest_actions, "list_projects", return_value=PROJECTS)
+    create = patch.object(interest_actions, "create_interest",
+                          return_value=CREATED_FROM_PROJECT)
+    # poll_refresh_task is used for both the build-task await and the
+    # refresh-task wait; return completed for both.
+    poll = patch.object(interest_actions, "poll_refresh_task",
+                        return_value={"status": "completed",
+                                      "result": {"count": 2}})
+    with lp, create, _refresh_patch(), poll as p:
+        result = CliRunner().invoke(
+            cli, ["interests", "from-project", "Spatial VQA", "--wait"],
+        )
+    assert result.exit_code == 0, result.output
+    # Build task (build-9) polled first, then the refresh task (refresh-1).
+    polled = [call.args[0] for call in p.call_args_list]
+    assert "build-9" in polled
+    assert "refresh-1" in polled
+    assert "recommendation(s) ready" in result.output
+
+
+def test_from_project_unknown_name_exits():
+    lp = patch.object(interest_actions, "list_projects", return_value=PROJECTS)
+    with lp:
+        result = CliRunner().invoke(
+            cli, ["interests", "from-project", "Nonexistent"],
+        )
+    assert result.exit_code != 0
+    assert "No project found" in result.output
+
+
+def test_from_project_curated_experiments_by_name():
+    experiments = [
+        {"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "name": "baseline-run"},
+        {"id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "name": "dpo-v2"},
+    ]
+    lp = patch.object(interest_actions, "list_projects", return_value=PROJECTS)
+    le = patch.object(interest_actions, "list_experiments",
+                      return_value=experiments)
+    create = patch.object(interest_actions, "create_interest",
+                          return_value=CREATED_FROM_PROJECT)
+    with lp, le, create as c, _refresh_patch():
+        result = CliRunner().invoke(
+            cli, ["interests", "from-project", "Spatial VQA",
+                  "-e", "baseline-run", "-e", "dpo-v2", "--no-auto-update"],
+        )
+
+    assert result.exit_code == 0, result.output
+    kwargs = c.call_args.kwargs
+    assert kwargs["included_experiment_ids"] == [
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    ]
+    assert kwargs["auto_update_from_experiments"] is False
+    assert "2 selected experiment" in result.output
+
+
+# ─── plain create ────────────────────────────────────────────────────────
+
+def test_create_refreshes_by_default():
+    created = {"id": "44444444-4444-4444-4444-444444444444",
+               "name": "RAG", "daily_count": 2, "is_active": True}
+    create = patch.object(interest_actions, "create_interest",
+                          return_value=created)
+    with create, _refresh_patch() as refresh:
+        result = CliRunner().invoke(
+            cli, ["interests", "create", "--name", "RAG",
+                  "--context", "retrieval augmented generation"],
+        )
+    assert result.exit_code == 0, result.output
+    refresh.assert_called_once()
+    assert refresh.call_args.kwargs["interest_id"] == created["id"]
+
+
+def test_create_no_refresh_shows_manual_hint():
+    created = {"id": "44444444-4444-4444-4444-444444444444",
+               "name": "RAG", "daily_count": 2, "is_active": True}
+    create = patch.object(interest_actions, "create_interest",
+                          return_value=created)
+    with create, _refresh_patch() as refresh:
+        result = CliRunner().invoke(
+            cli, ["interests", "create", "--name", "RAG",
+                  "--context", "retrieval augmented generation", "--no-refresh"],
+        )
+    assert result.exit_code == 0, result.output
+    refresh.assert_not_called()
+    assert "papers refresh" in result.output

--- a/tests/cli/test_outrider_actions.py
+++ b/tests/cli/test_outrider_actions.py
@@ -84,16 +84,38 @@ def test_resolve_interest_valid_uuid_probes_engine():
     gi.assert_called_once()
 
 
-def test_resolve_interest_auto_creates():
+def test_resolve_interest_auto_creates_via_repo_analysis():
+    """--auto-interest must run the analyze-repo flow (rich
+    ExperimentHistory context) rather than stuffing the URL into context."""
     uid = "6a730cc4-010c-49ce-9c7f-6d9c59431739"
-    with patch.object(outrider_actions, "create_interest", return_value={"id": uid}) as ci:
+    with patch.object(
+        outrider_actions, "create_interest_from_repo",
+        return_value={"id": uid, "history_extraction_task_id": "t-1"},
+    ) as ci:
         out = outrider_actions._resolve_interest_id(
             interest_id=None, auto_interest=True,
             repo="remyxai/outrider", repo_url="https://github.com/remyxai/outrider",
             api_key="k",
         )
     assert out == uid
-    assert ci.call_args.kwargs["context"] == "https://github.com/remyxai/outrider"
+    # Goes through the repo-analysis flow with the repo URL + the user's key,
+    # and does NOT provision paper PRs here (outrider init does that later).
+    assert ci.call_args.args[0] == "https://github.com/remyxai/outrider"
+    assert ci.call_args.kwargs["api_key"] == "k"
+    assert ci.call_args.kwargs["automate"] == "none"
+
+
+def test_resolve_interest_auto_create_surfaces_analysis_failure():
+    """A silent URL-stub; analysis failure must raise."""
+    with patch.object(
+        outrider_actions, "create_interest_from_repo",
+        side_effect=outrider_actions.RepoAnalysisError("rate limited"),
+    ):
+        with pytest.raises(click.ClickException):
+            outrider_actions._resolve_interest_id(
+                interest_id=None, auto_interest=True,
+                repo="o/r", repo_url="https://github.com/o/r", api_key="k",
+            )
 
 
 # ─── App-install preflight ──────────────────────────────────────────────────
@@ -228,7 +250,7 @@ def test_dry_run_makes_no_api_calls(monkeypatch):
     monkeypatch.setenv("REMYXAI_API_KEY", "k")
     with patch.object(outrider_actions, "is_app_installed") as inst, \
          patch.object(outrider_actions, "get_integration_status") as gs, \
-         patch.object(outrider_actions, "create_interest") as ci, \
+         patch.object(outrider_actions, "create_interest_from_repo") as ci, \
          patch.object(outrider_actions, "get_interest") as gi, \
          patch.object(outrider_actions, "provision_action") as prov:
         outrider_actions.handle_outrider_init(
@@ -267,10 +289,14 @@ def test_full_auto_flow_provisions_and_reports(monkeypatch):
         "result": {"pr_url": "https://github.com/o/r/pull/7", "merged": True,
                    "secret_set": True, "dispatched": True, "model_key_missing": False},
     }
+    calls = []
     with patch.object(outrider_actions, "get_interest", return_value={"id": uid}), \
          patch.object(outrider_actions, "is_app_installed", return_value=True), \
          patch.object(outrider_actions, "get_integration_status", return_value={"connected": True}), \
-         patch.object(outrider_actions, "provision_action", return_value={"task_id": "t1"}) as prov, \
+         patch.object(outrider_actions, "_kick_off_recommendations",
+                      side_effect=lambda *a, **k: calls.append("warm")) as warm, \
+         patch.object(outrider_actions, "provision_action",
+                      side_effect=lambda *a, **k: calls.append("provision") or {"task_id": "t1"}) as prov, \
          patch.object(outrider_actions, "poll_provision_action", return_value=completed):
         outrider_actions.handle_outrider_init(
             repo="owner/repo", interest_id=uid, auto_interest=False,
@@ -278,3 +304,25 @@ def test_full_auto_flow_provisions_and_reports(monkeypatch):
             dry_run=False, no_wait=False,
         )
     assert prov.call_args.kwargs["auto_merge"] is True
+    # Recommendations are warmed up before the first run is provisioned.
+    warm.assert_called_once()
+    assert warm.call_args.kwargs.get("wait") is True
+    assert calls == ["warm", "provision"]
+
+
+def test_no_wait_warms_without_blocking(monkeypatch):
+    """--no-wait still triggers the warm-up refresh, but doesn't block on it."""
+    monkeypatch.setenv("REMYXAI_API_KEY", "k")
+    uid = "6a730cc4-010c-49ce-9c7f-6d9c59431739"
+    with patch.object(outrider_actions, "get_interest", return_value={"id": uid}), \
+         patch.object(outrider_actions, "is_app_installed", return_value=True), \
+         patch.object(outrider_actions, "get_integration_status", return_value={"connected": True}), \
+         patch.object(outrider_actions, "_kick_off_recommendations") as warm, \
+         patch.object(outrider_actions, "provision_action", return_value={"task_id": "t1"}):
+        outrider_actions.handle_outrider_init(
+            repo="owner/repo", interest_id=uid, auto_interest=False,
+            mode="auto", anthropic_key=None, skip_confirm=True,
+            dry_run=False, no_wait=True,
+        )
+    warm.assert_called_once()
+    assert warm.call_args.kwargs.get("wait") is False


### PR DESCRIPTION
## Create Research Interests from repos & projects, with first recommendations built in

  Adds two new ways to spin up a Research Interest from the CLI, plus automatic recommendation population so a new interest is useful the moment it's
  created.

### What's new

  **`remyxai interests from-repo <github-url>`**
  
  Analyzes a GitHub repo and creates a Research Interest from a generated profile of the project (its themes, architecture, and history) so the interest tracks work that's actually relevant to that codebase. Optionally wire up automated paper PRs on the repo in the same step.

  ```bash
  remyxai interests from-repo https://github.com/owner/repo
  remyxai interests from-repo https://github.com/owner/repo \
    --name "My Project" --daily-count 3 --automate review --wait
  ```

  - `--automate {none|review|auto}` — paper-PR automation on the repo: `none` (default, just create the interest), `review` (open a setup PR to review), or `auto` (set it up automatically).
  
  **`remyxai interests from-project <name|uuid>`**
  
  Builds a Research Interest from a project's experiments, so recommendations are grounded in what you've been developing.

  ```bash
  remyxai interests from-project "Spatial VQA" --wait
  remyxai interests from-project <uuid> -e "baseline-run" -e "dpo-v2"
  ```

  - `-e/--include-experiment` — track a curated subset (repeatable); omit to track all.
  - `--no-auto-update` — pin the context instead of refreshing as new experiments land.

  **Recommendations are populated automatically**

  Every create command (`create`, `from-repo`, `from-project`) now kicks off a recommendations refresh so the interest has picks right away. Use `--wait` to block until they're ready, or `--no-refresh` to skip.

  **Richer `outrider init --auto-interest`**

  `--auto-interest` now builds the same repo-derived profile context as `from-repo`, and warms up recommendations before starting the first run so the initial pass has a real candidate pool to work from.

 ### API client

  - `interests`: `analyze_repo` / `poll_analyze_repo`; `create_interest` extended with repo-sourced, project-mode, and paper-PR-automation fields.
  - New `projects` module: `list_projects`, `list_experiments`.

 ### Tests
  
  Unit-tested across the new commands and flows (repo/project creation, automation modes, auto-refresh, and the Outrider auto-interest path); full suite green (135 passing).