### PR TITLE
Add `remyxai outrider trigger` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Set with `--mode` (default `auto`):
 - `auto` — provision, merge the setup PR, and start the first run
 - `review` — provision and open the setup PR for you to review and merge
 
+### Trigger a one-shot run
+
+Once Outrider is installed, `remyxai outrider trigger` dispatches an ad-hoc run targeting a specific paper or method — see [docs/method-targeted-runs.md](docs/method-targeted-runs.md) for the discover → trigger workflow.
+
 ### Credentials
 
 **You set up two things, once:**
@@ -149,6 +153,9 @@ Run any command with `--help` for full flag listings and examples.
 | `remyxai interests toggle <id>` | Flip active/inactive |
 | `remyxai interests delete <id>` | Remove an interest |
 | `remyxai outrider init` | Install Outrider on a GitHub repo via the Remyx App |
+| `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
+| `remyxai outrider trigger` | Dispatch a one-shot Outrider run; supports `--pin-method` / `--pin-arxiv` |
+| `remyxai search query <text>` | Search the engine's research-asset catalog |
 | `remyxai search list` | List recently added research assets (papers + Docker images) |
 | `remyxai search info <arxiv-id>` | Asset details |
 

--- a/docs/method-targeted-runs.md
+++ b/docs/method-targeted-runs.md
@@ -1,0 +1,75 @@
+---
+type: howto
+description: Discover a relevant paper or method, then dispatch a targeted Outrider run that implements it.
+tags: [outrider, cli, pin-method, pin-arxiv, workflow_dispatch]
+---
+
+# Method-targeted Outrider runs
+
+Once [Outrider](https://github.com/remyxai/outrider) is installed on a repo, you can dispatch a one-shot run targeting a specific paper or method — useful for kicking off an ad-hoc PR/Issue without waiting for the next scheduled run.
+
+The flow is two steps: **discover** an arxiv id you want implemented, then **trigger** the action with that id pinned.
+
+
+## 1. Discover
+
+### From the engine's recommendations for an interest
+
+```bash
+remyxai papers list --interest <uuid> --period week -n 10
+```
+
+Lists the engine's top recommendations for a Research Interest over the lookback window. Each entry shows the title, arxiv URL, and a relevance score. Note the arxiv id (e.g. `2410.20305v2`) of the candidate you want to implement.
+
+`remyxai papers digest` groups recommendations by interest if you want a cross-cutting view.
+
+### From a free-text search of the catalog
+
+```bash
+remyxai search query "knowledge distillation" -n 5
+```
+
+Searches the engine's research-asset catalog for matches against a method or topic. Useful when you have a method in mind but don't yet know the canonical paper.
+
+`remyxai search info <arxiv-id>` returns the full asset details (license, code repo, abstract) if you want to vet a candidate before triggering.
+
+
+## 2. Trigger
+
+```bash
+# Pin to a specific paper by arxiv id
+remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2
+
+# Or describe the method — the action resolves it to the top arxiv hit
+remyxai outrider trigger --repo owner/name --pin-method "knowledge distillation"
+```
+
+`--pin-method` accepts either a literal arxiv id (`NNNN.NNNNN[vN]`) or a free-text method query.
+
+- When the input matches the arxiv-id shape, the action uses **direct asset lookup** — the paper doesn't need to already be in the repo's candidate pool.
+- When the input is free text, the action runs the engine's search and pins to the top hit.
+
+In both cases the LLM selection pass is bypassed and the resolved paper goes straight to the implementation phase (Phase A audit → Phase B convention pass → Phase C test gate).
+
+### Pre-flight
+
+The command refuses to dispatch on repos that haven't been initialized with Outrider. If Outrider isn't installed yet, you'll see:
+
+```
+Outrider is not installed on owner/name. Install it first:
+  remyxai outrider init --repo owner/name
+```
+
+### --pin-arxiv (legacy)
+
+`--pin-arxiv` is the older form: it pins to an arxiv id but requires the paper to already be present in the repo's candidate pool. `--pin-method` is a superset (it works on arxiv ids outside the pool, via direct asset lookup), so prefer it for new uses.
+
+The two flags are mutually exclusive — setting both is a usage error.
+
+### Other options
+
+| Flag | Default | What it does |
+|---|---|---|
+| `--repo owner/name` | cwd's git remote | Target repo |
+| `--interest <uuid>` | the workflow's configured interest | Override the Research Interest for this run |
+| `--ref <branch>` | the repo's default branch | The git ref to dispatch against |

--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -24,7 +24,10 @@ from remyxai.cli.interest_actions import (
     handle_interests_delete,
     handle_interests_toggle,
 )
-from remyxai.cli.outrider_actions import handle_outrider_init
+from remyxai.cli.outrider_actions import (
+    handle_outrider_init,
+    handle_outrider_trigger,
+)
 from remyxai.cli.outrider_local import handle_outrider_setup_local
 
 
@@ -687,6 +690,61 @@ def outrider_setup_local(
         anthropic_key=anthropic_key,
         skip_confirm=skip_confirm,
         dry_run=dry_run,
+    )
+
+
+@outrider.command("trigger")
+@click.option("--repo", "repo", default=None,
+              help=(
+                  "Target repo as owner/name or a GitHub URL. Defaults to "
+                  "detecting from the current directory's git remote."
+              ))
+@click.option("--pin-method", "pin_method", default=None,
+              help=(
+                  "Method/technique query (e.g. \"knowledge distillation\") "
+                  "or a literal arxiv_id. The action's selection pass is "
+                  "bypassed and the resolved paper is implemented directly. "
+                  "Mutually exclusive with --pin-arxiv."
+              ))
+@click.option("--pin-arxiv", "pin_arxiv", default=None,
+              help=(
+                  "arxiv_id of a paper in the repo's candidate pool to "
+                  "implement directly. Use --pin-method for arxiv_ids not "
+                  "in the pool (it does a direct asset lookup)."
+              ))
+@click.option("--interest", "-i", "interest_id", default=None,
+              help="Override the ResearchInterest UUID for this run.")
+@click.option("--ref", "ref", default=None,
+              help="Git ref to dispatch on. Defaults to the repo's default "
+                   "branch.")
+def outrider_trigger(repo, pin_method, pin_arxiv, interest_id, ref):
+    """
+    Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
+
+    Useful for kicking off ad-hoc method-targeted PRs without waiting for
+    the next scheduled run. The repo must already have an Outrider workflow
+    installed (see `remyxai outrider init` / `setup-local`). Authenticates
+    via your local `gh` CLI — no Remyx engine round-trip.
+
+    Examples:
+
+      # Implement a specific method on a target repo
+      remyxai outrider trigger --repo owner/name \\
+        --pin-method "knowledge distillation"
+
+      # Re-run a previously surfaced paper by arxiv_id (works even if it's
+      # no longer in the candidate pool)
+      remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2
+
+      # Plain trigger — let the normal selection pass run
+      remyxai outrider trigger --repo owner/name
+    """
+    handle_outrider_trigger(
+        repo=repo,
+        pin_method=pin_method,
+        pin_arxiv=pin_arxiv,
+        interest_id=interest_id,
+        ref=ref,
     )
 
 

--- a/remyxai/cli/outrider_actions.py
+++ b/remyxai/cli/outrider_actions.py
@@ -426,11 +426,19 @@ def _outrider_workflow_exists(repo: str) -> bool:
 
 
 def _gh_dispatch_outrider(repo, branch, inputs):
-    """POST workflow_dispatch with the supplied inputs. Returns (ok, stderr)."""
+    """Dispatch the Outrider workflow with the supplied inputs.
+
+    Uses ``gh workflow run`` (not raw ``gh api``) because workflow_dispatch
+    expects inputs nested under ``inputs.*`` in the request body. The raw
+    POST endpoint accepts ``ref`` and ``inputs`` at the top level and
+    rejects any extra top-level keys with ``HTTP 422 "X is not a permitted
+    key"``; ``gh workflow run`` handles that wrapping for us.
+
+    Returns (ok, stderr) so the caller can map errors to user-facing hints.
+    """
     args = [
-        "gh", "api", "-X", "POST",
-        f"/repos/{repo}/actions/workflows/{WORKFLOW_FILENAME}/dispatches",
-        "-f", f"ref={branch}",
+        "gh", "workflow", "run", WORKFLOW_FILENAME,
+        "--repo", repo, "--ref", branch,
     ]
     for k, v in inputs.items():
         if v is None or v == "":

--- a/remyxai/cli/outrider_actions.py
+++ b/remyxai/cli/outrider_actions.py
@@ -389,3 +389,147 @@ def handle_outrider_init(
             "  ⚠ No model provider key set — connect Claude Code so the first "
             "run can complete.", fg="yellow",
         )
+
+
+# ─── outrider trigger ─────────────────────────────────────────────────────
+
+WORKFLOW_FILENAME = "outrider.yml"
+
+
+def _gh_default_branch(repo: str) -> Optional[str]:
+    """Return the repo's default branch via `gh api`, or None on failure."""
+    try:
+        out = subprocess.check_output(
+            ["gh", "api", f"/repos/{repo}", "--jq", ".default_branch"],
+            text=True, stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return out or None
+
+
+def _outrider_workflow_exists(repo: str) -> bool:
+    """Return True iff the repo has an Outrider workflow registered.
+
+    Probes the Actions API rather than the Contents API: the Contents
+    endpoint reports the file as soon as it's committed, but the Actions
+    endpoint only knows about a workflow after GitHub has indexed it for
+    dispatch — which is the precise capability we need for the trigger
+    call to succeed.
+    """
+    r = subprocess.run(
+        ["gh", "api", f"/repos/{repo}/actions/workflows/{WORKFLOW_FILENAME}",
+         "--silent"],
+        capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+
+def _gh_dispatch_outrider(repo, branch, inputs):
+    """POST workflow_dispatch with the supplied inputs. Returns (ok, stderr)."""
+    args = [
+        "gh", "api", "-X", "POST",
+        f"/repos/{repo}/actions/workflows/{WORKFLOW_FILENAME}/dispatches",
+        "-f", f"ref={branch}",
+    ]
+    for k, v in inputs.items():
+        if v is None or v == "":
+            continue
+        args.extend(["-f", f"{k}={v}"])
+    r = subprocess.run(args, capture_output=True, text=True)
+    return (r.returncode == 0, (r.stderr or "").strip())
+
+
+def _gh_latest_run_url(repo, sleep=time.sleep):
+    """Best-effort lookup of the most recent outrider.yml run URL."""
+    for _ in range(5):
+        try:
+            url = subprocess.check_output(
+                ["gh", "run", "list", "--repo", repo,
+                 "--workflow", WORKFLOW_FILENAME, "--limit", "1",
+                 "--json", "url", "--jq", ".[0].url"],
+                text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+            if url:
+                return url
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+        sleep(2)
+    return None
+
+
+def handle_outrider_trigger(
+    repo, pin_method, pin_arxiv, interest_id, ref,
+):
+    """Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
+
+    Called from `commands.outrider_trigger`. Mirrors `outrider setup-local`
+    by using the user's authenticated `gh` to POST the dispatch — no Remyx
+    engine round-trip, no Remyx App requirement. The repo must already
+    have an Outrider workflow installed (set up via `remyxai outrider init`
+    or `setup-local`).
+    """
+    # Inputs validation
+    if pin_method and pin_arxiv:
+        raise click.UsageError(
+            "--pin-method and --pin-arxiv are mutually exclusive."
+        )
+
+    # Repo resolution
+    resolved_repo = _normalize_repo(repo) if repo else _detect_github_repo_from_cwd()
+    if not resolved_repo:
+        raise click.UsageError(
+            "Could not determine target repo. Pass --repo owner/name or run "
+            "from inside a GitHub-origin git checkout."
+        )
+
+    # Pre-flight: refuse to dispatch on repos that aren't initialized.
+    # Surfaces a clear install hint instead of a generic 404 from the
+    # workflow_dispatch call below — the error is structurally about the
+    # repo's setup state, not the dispatch attempt itself.
+    if not _outrider_workflow_exists(resolved_repo):
+        raise click.ClickException(
+            f"Outrider is not installed on {resolved_repo}. Install it "
+            f"first:\n"
+            f"  remyxai outrider init --repo {resolved_repo}\n"
+            f"or, if your org can't grant the Remyx GitHub App yet:\n"
+            f"  remyxai outrider setup-local --repo {resolved_repo}"
+        )
+
+    # Ref defaults to the repo's default branch (so trigger works without
+    # the user knowing whether the repo's default is main, master, develop).
+    branch = ref or _gh_default_branch(resolved_repo)
+    if not branch:
+        raise click.ClickException(
+            f"Could not resolve a ref for {resolved_repo}. Pass --ref "
+            f"explicitly (e.g. --ref main)."
+        )
+
+    inputs = {
+        "pin-method": pin_method or "",
+        "pin-arxiv": pin_arxiv or "",
+        "interest-id": interest_id or "",
+    }
+
+    click.echo(f"Dispatching Outrider on {resolved_repo} (ref={branch})…")
+    if pin_method:
+        click.echo(f"  pin-method: {pin_method!r}")
+    if pin_arxiv:
+        click.echo(f"  pin-arxiv:  {pin_arxiv!r}")
+    if interest_id:
+        click.echo(f"  interest:   {interest_id}")
+
+    ok, stderr = _gh_dispatch_outrider(resolved_repo, branch, inputs)
+    if not ok:
+        hint = ""
+        if "403" in stderr or "permission" in stderr.lower():
+            hint = ("\n  Your gh token lacks the scope to dispatch workflows "
+                    "on this repo. Re-auth: `gh auth login --scopes workflow`.")
+        raise click.ClickException(f"workflow dispatch failed: {stderr}{hint}")
+
+    click.secho("✓ Dispatched.", fg="green", bold=True)
+    url = _gh_latest_run_url(resolved_repo)
+    if url:
+        click.echo(f"  Run: {url}")
+    else:
+        click.echo(f"  Run: https://github.com/{resolved_repo}/actions")

--- a/tests/cli/test_outrider_trigger.py
+++ b/tests/cli/test_outrider_trigger.py
@@ -25,7 +25,7 @@ from remyxai.cli.commands import cli
 
 
 def test_gh_dispatch_includes_pin_method_input():
-    """Non-empty inputs flow through to the gh-api -f args."""
+    """Non-empty inputs flow through to `gh workflow run -f <key>=<val>`."""
     captured = {}
 
     def fake_run(args, **kwargs):
@@ -40,7 +40,12 @@ def test_gh_dispatch_includes_pin_method_input():
         )
     assert ok is True
     args = captured["args"]
-    assert "ref=main" in args
+    # gh workflow run nests inputs under `inputs.*` server-side, so the
+    # raw POST never trips the "X is not a permitted key" rejection.
+    assert args[:3] == ["gh", "workflow", "run"]
+    assert "outrider.yml" in args
+    assert "--repo" in args and "owner/name" in args
+    assert "--ref" in args and "main" in args
     assert "pin-method=knowledge distillation" in args
     # Empty inputs are dropped, not sent as empty strings.
     assert not any(a.startswith("pin-arxiv=") for a in args)

--- a/tests/cli/test_outrider_trigger.py
+++ b/tests/cli/test_outrider_trigger.py
@@ -1,0 +1,246 @@
+"""Tests for `remyxai outrider trigger` — REMYX-148.
+
+Covers:
+- CLI wiring (option flags, mutex enforcement, click usage errors)
+- Repo resolution (explicit, auto-detect from git, missing)
+- Default ref resolution (from gh API) + explicit ref override
+- gh-dispatch invocation (correct path, ref, pin-method / pin-arxiv inputs)
+- Failure surfacing (404 not-installed, 403 missing-scope)
+- Run-URL best-effort lookup
+
+The subprocess calls are mocked at the patch boundary; no real network.
+"""
+import subprocess
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from remyxai.cli import outrider_actions
+from remyxai.cli.commands import cli
+
+
+# ─── _gh_dispatch_outrider ────────────────────────────────────────────────
+
+
+def test_gh_dispatch_includes_pin_method_input():
+    """Non-empty inputs flow through to the gh-api -f args."""
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        ok, err = outrider_actions._gh_dispatch_outrider(
+            "owner/name", "main",
+            {"pin-method": "knowledge distillation", "pin-arxiv": "",
+             "interest-id": ""},
+        )
+    assert ok is True
+    args = captured["args"]
+    assert "ref=main" in args
+    assert "pin-method=knowledge distillation" in args
+    # Empty inputs are dropped, not sent as empty strings.
+    assert not any(a.startswith("pin-arxiv=") for a in args)
+    assert not any(a.startswith("interest-id=") for a in args)
+
+
+def test_gh_dispatch_surfaces_stderr_on_failure():
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 1, "", "HTTP 404: Not Found")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        ok, err = outrider_actions._gh_dispatch_outrider(
+            "owner/name", "main", {"pin-method": "X"},
+        )
+    assert ok is False
+    assert "404" in err
+
+
+# ─── _gh_default_branch ───────────────────────────────────────────────────
+
+
+def test_default_branch_from_gh_api():
+    def fake_check_output(args, **kwargs):
+        return "develop\n"
+
+    with patch("subprocess.check_output", side_effect=fake_check_output):
+        assert outrider_actions._gh_default_branch("owner/name") == "develop"
+
+
+def test_default_branch_none_on_gh_failure():
+    def fake_check_output(args, **kwargs):
+        raise subprocess.CalledProcessError(1, args)
+
+    with patch("subprocess.check_output", side_effect=fake_check_output):
+        assert outrider_actions._gh_default_branch("owner/name") is None
+
+
+# ─── handle_outrider_trigger — high-level flow ────────────────────────────
+
+
+def test_trigger_mutex_pin_method_and_pin_arxiv():
+    with pytest.raises(click.UsageError, match="mutually exclusive"):
+        outrider_actions.handle_outrider_trigger(
+            repo="owner/name",
+            pin_method="X", pin_arxiv="2410.20305v2",
+            interest_id=None, ref=None,
+        )
+
+
+def test_trigger_errors_when_no_repo_and_not_in_git_checkout(monkeypatch):
+    monkeypatch.setattr(outrider_actions, "_detect_github_repo_from_cwd",
+                        lambda: None)
+    with pytest.raises(click.UsageError, match="Could not determine target repo"):
+        outrider_actions.handle_outrider_trigger(
+            repo=None, pin_method="X", pin_arxiv=None,
+            interest_id=None, ref=None,
+        )
+
+
+def test_trigger_refuses_when_workflow_not_installed(monkeypatch):
+    """Pre-flight: trigger refuses to dispatch on repos that haven't been
+    initialized with `remyxai outrider init`. Surfaces a clear install
+    hint before any dispatch attempt."""
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: False)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: pytest.fail(
+                            "must short-circuit before resolving ref"))
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider",
+                        lambda r, b, i: pytest.fail(
+                            "must short-circuit before dispatch"))
+
+    with pytest.raises(click.ClickException) as exc:
+        outrider_actions.handle_outrider_trigger(
+            repo="owner/name", pin_method="X", pin_arxiv=None,
+            interest_id=None, ref=None,
+        )
+    msg = exc.value.message.lower()
+    assert "not installed" in msg
+    assert "outrider init" in msg
+
+
+def test_trigger_403_surfaces_scope_hint(monkeypatch):
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider",
+                        lambda r, b, i: (False, "HTTP 403: missing permission"))
+
+    with pytest.raises(click.ClickException) as exc:
+        outrider_actions.handle_outrider_trigger(
+            repo="owner/name", pin_method="X", pin_arxiv=None,
+            interest_id=None, ref=None,
+        )
+    assert "scope" in exc.value.message.lower()
+
+
+def test_trigger_happy_path_with_pin_method(monkeypatch, capsys):
+    captured_dispatch = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        captured_dispatch["repo"] = repo
+        captured_dispatch["branch"] = branch
+        captured_dispatch["inputs"] = inputs
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda repo, sleep=None:
+                        "https://github.com/owner/name/actions/runs/123")
+
+    outrider_actions.handle_outrider_trigger(
+        repo="owner/name", pin_method="knowledge distillation",
+        pin_arxiv=None, interest_id=None, ref=None,
+    )
+
+    assert captured_dispatch["repo"] == "owner/name"
+    assert captured_dispatch["branch"] == "main"
+    assert captured_dispatch["inputs"]["pin-method"] == "knowledge distillation"
+    assert captured_dispatch["inputs"]["pin-arxiv"] == ""
+
+    out = capsys.readouterr().out
+    assert "Dispatched" in out
+    assert "runs/123" in out
+
+
+def test_trigger_uses_explicit_ref(monkeypatch):
+    seen = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        seen["branch"] = branch
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: pytest.fail("should not query when ref is set"))
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda repo, sleep=None: None)
+
+    outrider_actions.handle_outrider_trigger(
+        repo="owner/name", pin_method="X", pin_arxiv=None,
+        interest_id=None, ref="release/v2",
+    )
+    assert seen["branch"] == "release/v2"
+
+
+# ─── _outrider_workflow_exists ────────────────────────────────────────────
+
+
+def test_outrider_workflow_exists_true_when_gh_returns_zero():
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, "", "")
+    with patch("subprocess.run", side_effect=fake_run):
+        assert outrider_actions._outrider_workflow_exists("owner/name") is True
+
+
+def test_outrider_workflow_exists_false_on_404():
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 1, "", "HTTP 404")
+    with patch("subprocess.run", side_effect=fake_run):
+        assert outrider_actions._outrider_workflow_exists("owner/name") is False
+
+
+# ─── CLI integration via click runner ─────────────────────────────────────
+
+
+def test_cli_outrider_trigger_pin_method(monkeypatch):
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider",
+                        lambda r, b, i: (True, ""))
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda r, sleep=None: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "outrider", "trigger",
+        "--repo", "owner/name",
+        "--pin-method", "knowledge distillation",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "Dispatched" in result.output
+    assert "pin-method" in result.output
+
+
+def test_cli_outrider_trigger_mutex_via_click():
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "outrider", "trigger",
+        "--repo", "owner/name",
+        "--pin-method", "X", "--pin-arxiv", "2410.20305v2",
+    ])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()


### PR DESCRIPTION
## Summary

- New `remyxai outrider trigger` subcommand that dispatches a one-shot Outrider run on a repo via `workflow_dispatch`. Useful for kicking off ad-hoc paper-targeted runs without waiting for the next scheduled cycle.
- Inputs: `--repo`, `--pin-method` / `--pin-arxiv` (mutually exclusive), `--interest`, `--ref` (defaults to the repo's default branch).
- Pre-flight refuses to dispatch when the target repo doesn't have an Outrider workflow registered. The check probes the Actions API (not Contents), since the file existing on disk isn't the same as GitHub having indexed it for dispatch.
- Pairs with the new `pin-method` input on the Outrider action: `remyxai outrider trigger --repo owner/name --pin-method "knowledge distillation"`.
- Authenticates via the user's local `gh` CLI — no engine round-trip, no App requirement.

## Test plan

- [x] `pytest tests/cli/test_outrider_trigger.py` — 14 new tests passing
- [x] `pytest tests/ --ignore=tests/integration` — 147 unit tests pass, no regressions
- [ ] End-to-end: trigger an installed fork with `--pin-method "<query>"`, confirm dispatch + run URL surfaced
- [ ] End-to-end: trigger an uninstalled repo, confirm the install hint is shown before any dispatch attempt