### PR TITLE
search-method rename + pipeline docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,29 +39,7 @@ remyxai outrider trigger --repo your-org/your-repo --pin-arxiv 2402.02347v3
 | Method-targeted runs + team-scale patterns | [docs/method-targeted-runs.md](docs/method-targeted-runs.md) |
 | Research Interests: three ways to create one | [docs/research-interests.md](docs/research-interests.md) |
 | Install paths, credentials, bulk-install | [docs/install-paths.md](docs/install-paths.md) |
-
-## Command reference
-
-Run any command with `--help` for full flag listings and examples.
-
-| Command | What it does |
-|---|---|
-| `remyxai outrider init` | Install Outrider on a repo via the Remyx App |
-| `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
-| `remyxai outrider trigger` | Dispatch a one-shot run (`--search-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout`) |
-| `remyxai outrider set-provider-secret` | Set a per-provider API-key secret on a repo, safely |
-| `remyxai papers digest` | Recommendations grouped by Research Interest |
-| `remyxai papers list` | Recommendations flat view (filter by interest, period, source type) |
-| `remyxai papers refresh [--wait]` | Trigger a fresh ranking |
-| `remyxai interests list` | List your Research Interests |
-| `remyxai interests get <name-or-uuid>` | Show one interest |
-| `remyxai interests create` | Create an interest from free-form context |
-| `remyxai interests from-repo <github-url>` | Create an interest from a GitHub repo profile |
-| `remyxai interests from-project <name-or-uuid>` | Create an interest from a project's experiments |
-| `remyxai interests update <id>` | Edit name / context / daily count / active state |
-| `remyxai interests toggle <id>` | Flip active/inactive |
-| `remyxai search query <text>` | Search the engine's research-asset catalog |
-| `remyxai search info <arxiv-id>` | Asset details |
+| Full command reference | [docs/commands.md](docs/commands.md) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,140 +1,125 @@
-# Remyx AI command-line client
+# Remyx AI CLI
 
-CLI for the Remyx AI platform. Install [Outrider](https://github.com/remyxai/outrider) on a repo, manage Research Interests, browse recommended papers, and search for research assets — all from the terminal.
+Automate paper-to-PR delivery for the teams building on top of your code. Install [Outrider](https://github.com/remyxai/outrider) on a GitHub repo, and Remyx handles the loop end-to-end: **discovers** newly-published arXiv methods matching your team's work, **implements** them as draft PRs wired into your existing call sites, and **validates** each draft against the paper's reference implementation before it lands.
+
+The CLI is your control surface for the whole loop.
 
 ## Install
 
 ```bash
 pip install remyxai
+export REMYXAI_API_KEY=<your-key>   # from engine.remyx.ai/account
 ```
-
-## Authenticate
-
-Get an API key from [engine.remyx.ai/account](https://engine.remyx.ai/account) and export it:
-
-```bash
-export REMYXAI_API_KEY=<your-key>
-```
-
-All commands read this environment variable.
 
 ## Quickstart
 
-**See today's paper recommendations**
+**Install Outrider on your repo.** One command; Remyx handles the workflow, secrets, and first run server-side (no local git touched):
 
 ```bash
-remyxai papers digest
+remyxai outrider init --repo your-org/your-repo --auto-interest
 ```
 
-Shows recommended papers grouped by Research Interest. Use `remyxai papers list --interest <name-or-uuid>` for the flat view.
+`--auto-interest` extracts a Research Interest from your repo's commit history + README. It's what Outrider matches new arXiv papers against.
 
-**Create a Research Interest**
+**Three ways to trigger a run after init.** Each is a different level of specificity — pick by how much you want to override Remyx's own ranking:
 
 ```bash
-# Free-form context
-remyxai interests create \
-  --name "LLM Efficiency" \
-  --context "Quantization, speculative decoding, KV cache compression"
+# 1. Default: let Remyx pick the best implementable paper from your interest's
+#    ranked pool. Outrider's audit augments via agentic refine-queries;
+#    Claude Code selects the top match against your codebase's actual call sites.
+remyxai outrider trigger --repo your-org/your-repo
 
-# From a GitHub repo, or from one of your projects
-remyxai interests from-repo https://github.com/your-org/your-repo
-remyxai interests from-project "Spatial VQA"
+# 2. --search-method: override the ranker with a free-text query.
+#    Remyx searches its catalog and Outrider implements the top hit.
+#    Use when you know the method family but not the specific paper.
+remyxai outrider trigger --repo your-org/your-repo \
+  --search-method "riemannian preconditioning LoRA optimizer"
+
+# 3. --pin-arxiv: implement THIS specific paper. Bypasses ranking entirely.
+#    Use for reproducible re-runs, retries, or when you already know the arxiv id.
+remyxai outrider trigger --repo your-org/your-repo --pin-arxiv 2402.02347v3
 ```
 
-The pipeline matches new arXiv papers to your interests daily. See [Research Interests](#research-interests) for all three ways to create one.
+## How the pipeline scales
 
-**Install Outrider on a repo**
+Systematizing paper adoption across a team is usually a coordination problem, not a technical one — someone spots the paper, someone else evaluates fit, someone else implements, someone else reviews. Remyx + Outrider collapses that chain into a single automated pipeline that your team gates rather than staffs.
+
+**Discovery.** Every day, Remyx ranks the latest arXiv against your Research Interests (extracted from your codebase, curated per-team, or written by hand). See what surfaced:
 
 ```bash
-remyxai outrider init --repo owner/name --auto-interest
+remyxai papers digest                             # grouped by interest
+remyxai papers list --interest "My Project" -n 5  # flat view, top 5
 ```
 
-Sets up [Outrider](https://github.com/remyxai/outrider) on the target repo, server-side — your local git is never touched. See [Outrider](#outrider) for what it configures and the credentials it needs.
+For an interest, Outrider runs an audit pass that agentically explores your codebase, refines the recommendation pool via targeted searches for under-represented themes, and picks the paper most directly implementable against real call sites. Nothing gets drafted against imagined structure.
+
+**Implementation.** Once a paper is selected, Outrider clones the target repo and invokes Claude Code with a scoped brief: implement the paper's core contribution as a draft PR, wired into an existing call site, honoring your repo's contribution conventions (extracted from recent merged PRs). If the paper can't be cleanly scaffolded — no natural integration point, or too large a scope for one PR — Outrider opens a design-discussion Issue instead. The routing decision is measurement-based, not aspirational.
+
+**Validation.** Before a PR lands as ready-for-review, three passes run automatically:
+
+- **Fidelity audit** — clones the paper's reference implementation and diffs the draft against it, flagging any invented algorithms, wrong schemas, or missing components the paper actually requires. This is what catches plausibility-optimized fabrications before they reach a human reviewer.
+- **Convention pass** — folds the PR body and code layout to your target repo's contribution conventions (PR-body scaffold, AI-disclosure, docstring style, test co-location patterns), extracted from recent merged PRs.
+- **Test gate** — runs lint + targeted tests on the touched files; drops the Draft state only if lint passes and tests execute cleanly.
+
+Each pass writes its findings to the run's Actions Summary — you inspect one panel to see the drafting, verification, and refinement decisions for every recommendation.
+
+## Team-scale patterns
+
+**Bulk-install across an org's repos.** Install Outrider once across every active repo, each with an auto-extracted interest:
+
+```bash
+remyxai outrider init --bulk-repos repos.tsv --mode review
+```
+
+`repos.tsv` is a two-column file (`owner/name<TAB>interest-uuid-or-empty`); rows with an empty interest column trigger `--auto-interest`. See [docs/install-paths.md](docs/install-paths.md) for the full bulk flow.
+
+**Coordinate a specific paper across multiple frameworks.** Same paper, different codebases, one dispatch loop:
+
+```bash
+for repo in your-org/framework-a your-org/framework-b your-org/framework-c; do
+  remyxai outrider trigger --repo "$repo" --pin-arxiv 2402.02347v3
+done
+```
+
+Fidelity's cross-fork consistency check catches drift: if the same paper's core algorithm ends up implemented three different ways across three drafts, that's a signal about the codebase, not the paper.
+
+**Route the model provider per dispatch.** Different backends for different cost/quality tradeoffs:
+
+```bash
+remyxai outrider trigger --repo your-org/your-repo \
+  --pin-arxiv 2402.02347v3 --provider zai --model glm-5.2
+```
+
+See [`docs/method-targeted-runs.md`](docs/method-targeted-runs.md) for the full discover-then-trigger workflow (including `remyxai search query` to surface candidate methods before pinning).
 
 ## Research Interests
 
-A Research Interest is a named description of what to track; the recommendation pipeline matches new arXiv papers (and other sources) to it. Every create command kicks off a first recommendation pass automatically so the interest is populated right away — add `--wait` to block until the picks are ready, or `--no-refresh` to skip.
-
-### From free-form context
+An interest is a natural-language description of what your team tracks. Three ways to create one:
 
 ```bash
-remyxai interests create \
-  --name "LLM Efficiency" \
+# From free-form context (or a HuggingFace/GitHub URL, expanded server-side)
+remyxai interests create --name "LLM Efficiency" \
   --context "Quantization, speculative decoding, KV cache compression"
-```
 
-`--context` also accepts a HuggingFace or GitHub URL, which the server expands into context.
+# From a GitHub repo — extracts themes, architecture, and commit history
+remyxai interests from-repo https://github.com/your-org/your-repo --wait
 
-### From a GitHub repo
-
-`remyxai interests from-repo <github-url>` analyzes the repo, generates a profile of the project (themes, architecture, history), and uses it as the interest's context:
-
-```bash
-remyxai interests from-repo https://github.com/your-org/your-repo \
-  --name "My Project" --daily-count 3 --automate review --wait
-```
-
-- `--automate {none|review|auto}` — paper-PR automation on the repo: `none` (default; just create the interest), `review` (open a setup PR to review), or `auto` (set it up automatically). For the full repo setup, see [Outrider](#outrider).
-
-### From a project
-
-`remyxai interests from-project <name-or-uuid>` builds the interest's context from a project's experiments:
-
-```bash
-# Track all experiments on the project
+# From a project's experiments (all, or a curated subset via -e/--include-experiment)
 remyxai interests from-project "Spatial VQA" --wait
-
-# Or curate a subset, and pin the context
-remyxai interests from-project <uuid> -e "baseline-run" -e "dpo-v2" --no-auto-update
 ```
 
-- `-e/--include-experiment` — track a specific experiment (repeatable); omit to track all.
-- `--no-auto-update` — pin the context instead of refreshing as new experiments land.
+Every create command kicks off a first recommendation pass automatically. Use `--wait` to block until picks are ready.
 
-## Outrider
+## Credentials
 
-[Outrider](https://github.com/remyxai/outrider) is a GitHub Action that opens pull requests integrating relevant new papers into a repo. `remyxai outrider init` sets it up for you, server-side — your local git is never touched.
+You set up two things once:
 
-```bash
-remyxai outrider init --repo owner/name --auto-interest
-```
+1. **`REMYXAI_API_KEY`** in your shell (from [engine.remyx.ai/account](https://engine.remyx.ai/account)) — authorizes the CLI.
+2. **A model provider** connected on the [Integrations page](https://engine.remyx.ai/integrations) — Claude Code today, more providers coming soon. Outrider calls the model at runtime with this.
 
-This uses the **Remyx GitHub App** (`remyx-ai[bot]`) to:
+During provisioning, the Remyx GitHub App creates the target repo's secrets for you (a scoped `REMYX_API_KEY` and the provider's key) — no manual `gh secret set` steps. If the App isn't installed on the target yet, the CLI surfaces the install link.
 
-- Create a Research Interest from the repo (`--auto-interest`), or use an existing one (`--interest <uuid>`)
-- Write the Outrider workflow to the target repo and set its required Actions secrets
-- Open a bot-authored setup PR — and, in `auto` mode, merge it and fire the first run
-
-### Modes
-
-Set with `--mode` (default `auto`):
-
-- `auto` — provision, merge the setup PR, and start the first run
-- `review` — provision and open the setup PR for you to review and merge
-
-### Trigger a one-shot run
-
-Once Outrider is installed, `remyxai outrider trigger` dispatches an ad-hoc run targeting a specific paper or method — see [docs/method-targeted-runs.md](docs/method-targeted-runs.md) for the discover → trigger workflow.
-
-### Credentials
-
-**You set up two things, once:**
-
-1. Your `REMYXAI_API_KEY`, exported in your shell (see [Authenticate](#authenticate)) — this authorizes the CLI.
-2. A model provider connected on the [Integrations page](https://engine.remyx.ai/integrations) — Claude Code today, more providers coming soon. The Action needs this to call the model.
-
-**Remyx handles the rest.** You never create repo secrets by hand. During provisioning the Remyx GitHub App sets two Actions secrets on the target repo for you:
-
-| Repo secret | What it is |
-|---|---|
-| `REMYX_API_KEY` | A scoped automation key Remyx mints just for this repo — *not* your personal `REMYXAI_API_KEY`, and revocable on its own. |
-| `ANTHROPIC_API_KEY` (or your provider's key) | Copied from the provider you connected on the Integrations page, so the Action can call the model at runtime. |
-
-> **No provider connected yet?** As a one-time fallback, pass `--anthropic-key` (or set `ANTHROPIC_API_KEY`) and the CLI connects it for you. Otherwise no model key ever goes on the command line.
-
-If the Remyx GitHub App isn't installed on the target repo yet, the command surfaces the install link.
-
-For the no-App `setup-local` path, the `--no-cron` switch, and `--bulk-repos` onboarding across many repos at once, see [docs/install-paths.md](docs/install-paths.md).
+For the no-App `setup-local` path (uses your own `gh`), see [docs/install-paths.md](docs/install-paths.md).
 
 ## Command reference
 
@@ -142,10 +127,13 @@ Run any command with `--help` for full flag listings and examples.
 
 | Command | What it does |
 |---|---|
+| `remyxai outrider init` | Install Outrider on a repo via the Remyx App |
+| `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
+| `remyxai outrider trigger` | Dispatch a one-shot run (`--search-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout`) |
+| `remyxai outrider set-provider-secret` | Set a per-provider API-key secret on a repo, safely |
 | `remyxai papers digest` | Recommendations grouped by Research Interest |
 | `remyxai papers list` | Recommendations flat view (filter by interest, period, source type) |
 | `remyxai papers refresh [--wait]` | Trigger a fresh ranking |
-| `remyxai papers refresh-status <task_id>` | Poll a refresh task |
 | `remyxai interests list` | List your Research Interests |
 | `remyxai interests get <name-or-uuid>` | Show one interest |
 | `remyxai interests create` | Create an interest from free-form context |
@@ -153,13 +141,7 @@ Run any command with `--help` for full flag listings and examples.
 | `remyxai interests from-project <name-or-uuid>` | Create an interest from a project's experiments |
 | `remyxai interests update <id>` | Edit name / context / daily count / active state |
 | `remyxai interests toggle <id>` | Flip active/inactive |
-| `remyxai interests delete <id>` | Remove an interest |
-| `remyxai outrider init` | Install Outrider on a GitHub repo via the Remyx App |
-| `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
-| `remyxai outrider trigger` | Dispatch a one-shot Outrider run; supports `--search-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout` |
-| `remyxai outrider set-provider-secret` | Set a per-provider API-key secret on a repo, safely (avoids the `gh secret set --body -` truncation trap) |
 | `remyxai search query <text>` | Search the engine's research-asset catalog |
-| `remyxai search list` | List recently added research assets (papers + Docker images) |
 | `remyxai search info <arxiv-id>` | Asset details |
 
 ## Development
@@ -168,16 +150,11 @@ Run any command with `--help` for full flag listings and examples.
 git clone https://github.com/remyxai/remyxai-cli
 cd remyxai-cli
 pip install -e .
-
-# Run tests
 pytest tests/
 ```
-
-Releases: tag a `v*` release on GitHub and the `publish.yml` workflow builds + uploads to PyPI via Trusted Publishing (no API token stored).
 
 ## Links
 
 - [Outrider](https://github.com/remyxai/outrider) — the GitHub Action this CLI installs
 - [engine.remyx.ai](https://engine.remyx.ai) — web app, account settings, API key
 - [Issues](https://github.com/remyxai/remyxai-cli/issues) — bug reports and feature requests
-```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Remyx AI CLI
 
-Automate paper-to-PR delivery for the teams building on top of your code. Install [Outrider](https://github.com/remyxai/outrider) on a GitHub repo, and Remyx handles the loop end-to-end: **discovers** newly-published arXiv methods matching your team's work, **implements** them as draft PRs wired into your existing call sites, and **validates** each draft against the paper's reference implementation before it lands.
-
-The CLI is your control surface for the whole loop.
+Install [Outrider](https://github.com/remyxai/outrider) on a repo, and Remyx handles the loop end-to-end: **discovers** newly-published arXiv methods matching your team's work, **implements** them as draft PRs, and **validates** each against the paper's reference before it lands.
 
 ## Install
 
@@ -13,113 +11,34 @@ export REMYXAI_API_KEY=<your-key>   # from engine.remyx.ai/account
 
 ## Quickstart
 
-**Install Outrider on your repo.** One command; Remyx handles the workflow, secrets, and first run server-side (no local git touched):
+Install Outrider on a repo — server-side, no local git touched:
 
 ```bash
 remyxai outrider init --repo your-org/your-repo --auto-interest
 ```
 
-`--auto-interest` extracts a Research Interest from your repo's commit history + README. It's what Outrider matches new arXiv papers against.
-
-**Three ways to trigger a run after init.** Each is a different level of specificity — pick by how much you want to override Remyx's own ranking:
+Trigger a run — three modes of specificity:
 
 ```bash
-# 1. Default: let Remyx pick the best implementable paper from your interest's
-#    ranked pool. Outrider's audit augments via agentic refine-queries;
-#    Claude Code selects the top match against your codebase's actual call sites.
+# 1. default — Remyx picks from the ranked pool; Outrider's audit augments via agentic search
 remyxai outrider trigger --repo your-org/your-repo
 
-# 2. --search-method: override the ranker with a free-text query.
-#    Remyx searches its catalog and Outrider implements the top hit.
-#    Use when you know the method family but not the specific paper.
+# 2. --search-method — override the pool with a free-text query, implement the top hit
 remyxai outrider trigger --repo your-org/your-repo \
   --search-method "riemannian preconditioning LoRA optimizer"
 
-# 3. --pin-arxiv: implement THIS specific paper. Bypasses ranking entirely.
-#    Use for reproducible re-runs, retries, or when you already know the arxiv id.
+# 3. --pin-arxiv — exact paper, bypasses selection entirely
 remyxai outrider trigger --repo your-org/your-repo --pin-arxiv 2402.02347v3
 ```
 
-## How the pipeline scales
+## Documentation
 
-Systematizing paper adoption across a team is usually a coordination problem, not a technical one — someone spots the paper, someone else evaluates fit, someone else implements, someone else reviews. Remyx + Outrider collapses that chain into a single automated pipeline that your team gates rather than staffs.
-
-**Discovery.** Every day, Remyx ranks the latest arXiv against your Research Interests (extracted from your codebase, curated per-team, or written by hand). See what surfaced:
-
-```bash
-remyxai papers digest                             # grouped by interest
-remyxai papers list --interest "My Project" -n 5  # flat view, top 5
-```
-
-For an interest, Outrider runs an audit pass that agentically explores your codebase, refines the recommendation pool via targeted searches for under-represented themes, and picks the paper most directly implementable against real call sites. Nothing gets drafted against imagined structure.
-
-**Implementation.** Once a paper is selected, Outrider clones the target repo and invokes Claude Code with a scoped brief: implement the paper's core contribution as a draft PR, wired into an existing call site, honoring your repo's contribution conventions (extracted from recent merged PRs). If the paper can't be cleanly scaffolded — no natural integration point, or too large a scope for one PR — Outrider opens a design-discussion Issue instead. The routing decision is measurement-based, not aspirational.
-
-**Validation.** Before a PR lands as ready-for-review, three passes run automatically:
-
-- **Fidelity audit** — clones the paper's reference implementation and diffs the draft against it, flagging any invented algorithms, wrong schemas, or missing components the paper actually requires. This is what catches plausibility-optimized fabrications before they reach a human reviewer.
-- **Convention pass** — folds the PR body and code layout to your target repo's contribution conventions (PR-body scaffold, AI-disclosure, docstring style, test co-location patterns), extracted from recent merged PRs.
-- **Test gate** — runs lint + targeted tests on the touched files; drops the Draft state only if lint passes and tests execute cleanly.
-
-Each pass writes its findings to the run's Actions Summary — you inspect one panel to see the drafting, verification, and refinement decisions for every recommendation.
-
-## Team-scale patterns
-
-**Bulk-install across an org's repos.** Install Outrider once across every active repo, each with an auto-extracted interest:
-
-```bash
-remyxai outrider init --bulk-repos repos.tsv --mode review
-```
-
-`repos.tsv` is a two-column file (`owner/name<TAB>interest-uuid-or-empty`); rows with an empty interest column trigger `--auto-interest`. See [docs/install-paths.md](docs/install-paths.md) for the full bulk flow.
-
-**Coordinate a specific paper across multiple frameworks.** Same paper, different codebases, one dispatch loop:
-
-```bash
-for repo in your-org/framework-a your-org/framework-b your-org/framework-c; do
-  remyxai outrider trigger --repo "$repo" --pin-arxiv 2402.02347v3
-done
-```
-
-Fidelity's cross-fork consistency check catches drift: if the same paper's core algorithm ends up implemented three different ways across three drafts, that's a signal about the codebase, not the paper.
-
-**Route the model provider per dispatch.** Different backends for different cost/quality tradeoffs:
-
-```bash
-remyxai outrider trigger --repo your-org/your-repo \
-  --pin-arxiv 2402.02347v3 --provider zai --model glm-5.2
-```
-
-See [`docs/method-targeted-runs.md`](docs/method-targeted-runs.md) for the full discover-then-trigger workflow (including `remyxai search query` to surface candidate methods before pinning).
-
-## Research Interests
-
-An interest is a natural-language description of what your team tracks. Three ways to create one:
-
-```bash
-# From free-form context (or a HuggingFace/GitHub URL, expanded server-side)
-remyxai interests create --name "LLM Efficiency" \
-  --context "Quantization, speculative decoding, KV cache compression"
-
-# From a GitHub repo — extracts themes, architecture, and commit history
-remyxai interests from-repo https://github.com/your-org/your-repo --wait
-
-# From a project's experiments (all, or a curated subset via -e/--include-experiment)
-remyxai interests from-project "Spatial VQA" --wait
-```
-
-Every create command kicks off a first recommendation pass automatically. Use `--wait` to block until picks are ready.
-
-## Credentials
-
-You set up two things once:
-
-1. **`REMYXAI_API_KEY`** in your shell (from [engine.remyx.ai/account](https://engine.remyx.ai/account)) — authorizes the CLI.
-2. **A model provider** connected on the [Integrations page](https://engine.remyx.ai/integrations) — Claude Code today, more providers coming soon. Outrider calls the model at runtime with this.
-
-During provisioning, the Remyx GitHub App creates the target repo's secrets for you (a scoped `REMYX_API_KEY` and the provider's key) — no manual `gh secret set` steps. If the App isn't installed on the target yet, the CLI surfaces the install link.
-
-For the no-App `setup-local` path (uses your own `gh`), see [docs/install-paths.md](docs/install-paths.md).
+| Topic | Doc |
+|---|---|
+| Pipeline: discovery → implementation → validation | [docs/pipeline.md](docs/pipeline.md) |
+| Method-targeted runs + team-scale patterns | [docs/method-targeted-runs.md](docs/method-targeted-runs.md) |
+| Research Interests: three ways to create one | [docs/research-interests.md](docs/research-interests.md) |
+| Install paths, credentials, bulk-install | [docs/install-paths.md](docs/install-paths.md) |
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Run any command with `--help` for full flag listings and examples.
 | `remyxai interests delete <id>` | Remove an interest |
 | `remyxai outrider init` | Install Outrider on a GitHub repo via the Remyx App |
 | `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
-| `remyxai outrider trigger` | Dispatch a one-shot Outrider run; supports `--pin-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout` |
+| `remyxai outrider trigger` | Dispatch a one-shot Outrider run; supports `--search-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout` |
 | `remyxai outrider set-provider-secret` | Set a per-provider API-key secret on a repo, safely (avoids the `gh secret set --body -` truncation trap) |
 | `remyxai search query <text>` | Search the engine's research-asset catalog |
 | `remyxai search list` | List recently added research assets (papers + Docker images) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,52 @@
+---
+type: reference
+description: Full command reference for the Remyx AI CLI.
+tags: [cli, reference, commands]
+---
+
+# Command reference
+
+Run any command with `--help` for full flag listings and examples — that's the authoritative source.
+
+## Outrider
+
+| Command | What it does |
+|---|---|
+| `remyxai outrider init` | Install Outrider on a repo via the Remyx App |
+| `remyxai outrider setup-local` | Install Outrider via your own `gh` (no Remyx App) |
+| `remyxai outrider trigger` | Dispatch a one-shot run (`--search-method` / `--pin-arxiv` / `--provider` / `--model` / `--claude-timeout`) |
+| `remyxai outrider set-provider-secret` | Set a per-provider API-key secret on a repo, safely |
+
+See also: [method-targeted-runs.md](method-targeted-runs.md) for `outrider trigger` in depth, [install-paths.md](install-paths.md) for `init` vs `setup-local` and bulk-install.
+
+## Papers
+
+| Command | What it does |
+|---|---|
+| `remyxai papers digest` | Recommendations grouped by Research Interest |
+| `remyxai papers list` | Recommendations flat view (filter by interest, period, source type) |
+| `remyxai papers refresh [--wait]` | Trigger a fresh ranking |
+| `remyxai papers refresh-status <task_id>` | Poll a refresh task |
+
+## Interests
+
+| Command | What it does |
+|---|---|
+| `remyxai interests list` | List your Research Interests |
+| `remyxai interests get <name-or-uuid>` | Show one interest |
+| `remyxai interests create` | Create an interest from free-form context |
+| `remyxai interests from-repo <github-url>` | Create an interest from a GitHub repo profile |
+| `remyxai interests from-project <name-or-uuid>` | Create an interest from a project's experiments |
+| `remyxai interests update <id>` | Edit name / context / daily count / active state |
+| `remyxai interests toggle <id>` | Flip active/inactive |
+| `remyxai interests delete <id>` | Remove an interest |
+
+See also: [research-interests.md](research-interests.md) for the three interest-creation flavors in depth.
+
+## Search
+
+| Command | What it does |
+|---|---|
+| `remyxai search query <text>` | Search the engine's research-asset catalog |
+| `remyxai search list` | List recently added research assets (papers + Docker images) |
+| `remyxai search info <arxiv-id>` | Asset details |

--- a/docs/method-targeted-runs.md
+++ b/docs/method-targeted-runs.md
@@ -163,3 +163,44 @@ remyxai outrider trigger \
 ```
 
 The CLI rejects values below 60 seconds at the command boundary. The action itself parses the input as an integer; non-integer values fail fast at the workflow's `INPUT_CLAUDE_TIMEOUT` parser.
+
+
+## Team-scale patterns
+
+### Bulk-install across an org's repos
+
+Install Outrider once across every active repo, each with an auto-extracted interest:
+
+```bash
+remyxai outrider init --bulk-repos repos.tsv --mode review
+```
+
+`repos.tsv` is a two-column file (`owner/name<TAB>interest-uuid-or-empty`); rows with an empty interest column trigger `--auto-interest`. See [install-paths.md](install-paths.md) for the full bulk flow.
+
+### Coordinate a specific paper across multiple frameworks
+
+Same paper, different codebases, one dispatch loop:
+
+```bash
+for repo in your-org/framework-a your-org/framework-b your-org/framework-c; do
+  remyxai outrider trigger --repo "$repo" --pin-arxiv 2402.02347v3
+done
+```
+
+Fidelity's cross-fork consistency check catches drift: if the same paper's core algorithm ends up implemented three different ways across three drafts, that's a signal about the codebase, not the paper.
+
+### Retry a run under a different provider
+
+If a run timed out under GLM (which tends to run 1.1–2.7× slower than Anthropic on the same paper), retry it under Anthropic:
+
+```bash
+# First attempt hit the wall-clock ceiling under GLM
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3 \
+  --provider zai --claude-timeout 1500
+
+# Retry under Anthropic at the default timeout
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3 \
+  --provider anthropic
+```
+
+`--pin-arxiv` guarantees reproducibility across retries — the second attempt implements the same paper the first one targeted, so the comparison isolates the provider/backend variable.

--- a/docs/method-targeted-runs.md
+++ b/docs/method-targeted-runs.md
@@ -1,14 +1,20 @@
 ---
 type: howto
 description: Discover a relevant paper or method, then dispatch a targeted Outrider run that implements it.
-tags: [outrider, cli, pin-method, pin-arxiv, workflow_dispatch]
+tags: [outrider, cli, search-method, pin-arxiv, workflow_dispatch]
 ---
 
 # Method-targeted Outrider runs
 
 Once [Outrider](https://github.com/remyxai/outrider) is installed on a repo, you can dispatch a one-shot run targeting a specific paper or method — useful for kicking off an ad-hoc PR/Issue without waiting for the next scheduled run.
 
-The flow is two steps: **discover** an arxiv id you want implemented, then **trigger** the action with that id pinned.
+Three modes of specificity, in ascending order of override:
+
+1. **Default (no pin)** — Remyx ranks candidates from the interest-scoped pool + Outrider's audit augments via agentic refine-queries; Claude Code picks the best implementation from the ranked pool.
+2. **`--search-method`** — overrides the ranked pool with an engine search on your query; implements the top hit.
+3. **`--pin-arxiv`** — implements the exact arxiv paper; bypasses ranking entirely.
+
+The flow is two steps: **discover** what you want implemented, then **trigger** the action.
 
 
 ## 1. Discover
@@ -19,14 +25,14 @@ The flow is two steps: **discover** an arxiv id you want implemented, then **tri
 remyxai papers list --interest <uuid> --period week -n 10
 ```
 
-Lists the engine's top recommendations for a Research Interest over the lookback window. Each entry shows the title, arxiv URL, and a relevance score. Note the arxiv id (e.g. `2410.20305v2`) of the candidate you want to implement.
+Lists the engine's top recommendations for a Research Interest over the lookback window. Each entry shows the title, arxiv URL, and a relevance score. Note the arxiv id (e.g. `2402.02347v3`) of the candidate you want to implement.
 
 `remyxai papers digest` groups recommendations by interest if you want a cross-cutting view.
 
 ### From a free-text search of the catalog
 
 ```bash
-remyxai search query "knowledge distillation" -n 5
+remyxai search query "riemannian preconditioning LoRA" -n 5
 ```
 
 Searches the engine's research-asset catalog for matches against a method or topic. Useful when you have a method in mind but don't yet know the canonical paper.
@@ -36,20 +42,36 @@ Searches the engine's research-asset catalog for matches against a method or top
 
 ## 2. Trigger
 
-```bash
-# Pin to a specific paper by arxiv id
-remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2
+### `--pin-arxiv` — exact paper (recommended for known arxiv ids)
 
-# Or describe the method — the action resolves it to the top arxiv hit
-remyxai outrider trigger --repo owner/name --pin-method "knowledge distillation"
+```bash
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3
 ```
 
-`--pin-method` accepts either a literal arxiv id (`NNNN.NNNNN[vN]`) or a free-text method query.
+Implements exactly this paper. Bypasses the ranker's pool entirely — Remyx fetches the paper directly from its asset catalog and forwards it to Claude Code for implementation. Works even if the paper isn't in the repo's interest-scoped candidate pool.
 
-- When the input matches the arxiv-id shape, the action uses **direct asset lookup** — the paper doesn't need to already be in the repo's candidate pool.
-- When the input is free text, the action runs the engine's search and pins to the top hit.
+Use for:
+- Reproducible re-runs (same paper, same repo, deterministic paper input)
+- Retries after a timeout or backend failure
+- Cases where you've already identified the paper via `remyxai search info` or elsewhere
 
-In both cases the LLM selection pass is bypassed and the resolved paper goes straight to the implementation phase (Phase A audit → Phase B convention pass → Phase C test gate).
+### `--search-method` — free-text method query
+
+```bash
+remyxai outrider trigger --repo owner/name \
+  --search-method "riemannian preconditioning LoRA optimizer"
+```
+
+Runs an engine search over the paper catalog and implements the top hit. Use for exploratory dispatches when you know the method family but haven't pinned down a specific paper.
+
+The top-hit semantic means: **whichever arxiv paper the engine returns first for your query gets implemented**. Not deterministic across search index updates. If reproducibility matters, use `--pin-arxiv` with the resolved arxiv id instead.
+
+The two flags are mutually exclusive — setting both is a usage error.
+
+### Both paths bypass selection
+
+In both `--pin-arxiv` and `--search-method` cases, the LLM selection pass is skipped and the resolved paper goes straight to preflight → implementation → refinement chain (fidelity audit → convention pass → test gate).
+
 
 ### Pre-flight
 
@@ -60,11 +82,6 @@ Outrider is not installed on owner/name. Install it first:
   remyxai outrider init --repo owner/name
 ```
 
-### --pin-arxiv (legacy)
-
-`--pin-arxiv` is the older form: it pins to an arxiv id but requires the paper to already be present in the repo's candidate pool. `--pin-method` is a superset (it works on arxiv ids outside the pool, via direct asset lookup), so prefer it for new uses.
-
-The two flags are mutually exclusive — setting both is a usage error.
 
 ### Other options
 
@@ -91,15 +108,15 @@ remyxai outrider set-provider-secret \
 
 # 2. Route this run at z.ai's GLM-5.2; scheduled cron runs continue
 #    to use the workflow's default (Anthropic).
-remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2 \
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3 \
   --provider zai --model glm-5.2
 
 # Or compare against an older z.ai model on the same paper/repo:
-remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2 \
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3 \
   --provider zai --model glm-4.6
 
 # Pin to a specific Anthropic model (e.g. for an A/B against Sonnet):
-remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2 \
+remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3 \
   --provider anthropic --model claude-sonnet-4-6
 ```
 
@@ -141,8 +158,8 @@ The action's `claude-timeout` input ceilings the wall-clock budget on the implem
 ```bash
 # Bump to 1200s for a sprawling monorepo on a slower backend.
 remyxai outrider trigger \
-  --repo owner/name --pin-method 2410.20305v2 \
-  --backend glm --claude-timeout 1200
+  --repo owner/name --pin-arxiv 2402.02347v3 \
+  --provider zai --claude-timeout 1200
 ```
 
 The CLI rejects values below 60 seconds at the command boundary. The action itself parses the input as an integer; non-integer values fail fast at the workflow's `INPUT_CLAUDE_TIMEOUT` parser.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,46 @@
+---
+type: reference
+description: How Remyx + Outrider automates the paper-adoption pipeline — discovery, implementation, validation.
+tags: [outrider, pipeline, discovery, implementation, validation]
+---
+
+# Pipeline: discovery → implementation → validation
+
+Systematizing paper adoption across a team is usually a coordination problem, not a technical one — someone spots the paper, someone else evaluates fit, someone else implements, someone else reviews. Remyx + Outrider collapses that chain into a single automated pipeline that your team gates rather than staffs.
+
+## Discovery
+
+Every day, Remyx ranks the latest arXiv against your Research Interests (extracted from your codebase, curated per-team, or written by hand):
+
+```bash
+remyxai papers digest                             # grouped by interest
+remyxai papers list --interest "My Project" -n 5  # flat view, top 5
+```
+
+When Outrider fires on a repo, it runs an **audit pass** that agentically explores the codebase, refines the recommendation pool via targeted searches for under-represented themes, and picks the paper most directly implementable against real call sites. Nothing gets drafted against imagined structure.
+
+## Implementation
+
+Once a paper is selected, Outrider clones the target repo and invokes Claude Code with a scoped brief: implement the paper's core contribution as a draft PR, wired into an existing call site, honoring your repo's contribution conventions (extracted from recent merged PRs).
+
+If the paper can't be cleanly scaffolded — no natural integration point, or too large a scope for one PR — Outrider opens a design-discussion Issue instead. The routing decision is **measurement-based**, not aspirational: the coding agent must find a real call site before drafting a PR.
+
+## Validation
+
+Before a PR lands as ready-for-review, three passes run automatically:
+
+- **Fidelity audit** — clones the paper's reference implementation and diffs the draft against it, flagging any invented algorithms, wrong schemas, or missing components the paper actually requires. This is what catches plausibility-optimized fabrications before they reach a human reviewer.
+- **Convention pass** — folds the PR body and code layout to your target repo's contribution conventions (PR-body scaffold, AI-disclosure, docstring style, test co-location patterns), extracted from recent merged PRs.
+- **Test gate** — runs lint + targeted tests on the touched files; drops the Draft state only if lint passes and tests execute cleanly.
+
+Each pass writes its findings to the run's Actions Summary — you inspect one panel to see the drafting, verification, and refinement decisions for every recommendation.
+
+## Where teams sit in the loop
+
+You gate rather than staff:
+
+- **Configure** — set up an interest that reflects what your team tracks (via `interests from-repo` for codebase-anchored, or `interests create` for hand-curated)
+- **Review** — Outrider files Draft PRs and design Issues; you review, request changes, or merge
+- **Steer** — dispatch ad-hoc runs on specific papers via `--pin-arxiv` or `--search-method` when you have a specific target in mind (see [method-targeted-runs.md](method-targeted-runs.md))
+
+The automation catches the discovery gap (papers you'd have missed) and the fabrication gap (implementations that look plausible but aren't). Your review time stays focused on architecture, scope, and merge-readiness.

--- a/docs/research-interests.md
+++ b/docs/research-interests.md
@@ -1,0 +1,72 @@
+---
+type: reference
+description: Three ways to create a Research Interest — free-form context, from a repo, or from a project.
+tags: [interests, cli, research-profile]
+---
+
+# Research Interests
+
+A Research Interest is a natural-language description of what your team tracks. The recommendation pipeline matches new arXiv papers (and other sources) to it. Every create command kicks off a first recommendation pass automatically — add `--wait` to block until picks are ready, or `--no-refresh` to skip.
+
+## From free-form context
+
+```bash
+remyxai interests create \
+  --name "LLM Efficiency" \
+  --context "Quantization, speculative decoding, KV cache compression"
+```
+
+`--context` also accepts a HuggingFace or GitHub URL, which the server expands into context.
+
+## From a GitHub repo
+
+`remyxai interests from-repo <github-url>` analyzes the repo, generates a profile of the project (themes, architecture, history), and uses it as the interest's context:
+
+```bash
+remyxai interests from-repo https://github.com/your-org/your-repo \
+  --name "My Project" --daily-count 3 --automate review --wait
+```
+
+- `--automate {none|review|auto}` — paper-PR automation on the repo:
+  - `none` (default) — just create the interest
+  - `review` — open a setup PR to review
+  - `auto` — set it up automatically
+
+For the full repo setup (bulk-install, credentials, secrets), see [install-paths.md](install-paths.md).
+
+## From a project
+
+`remyxai interests from-project <name-or-uuid>` builds the interest's context from a Remyx project's experiments:
+
+```bash
+# Track all experiments on the project
+remyxai interests from-project "Spatial VQA" --wait
+
+# Or curate a subset, and pin the context
+remyxai interests from-project <uuid> -e "baseline-run" -e "dpo-v2" --no-auto-update
+```
+
+- `-e/--include-experiment` — track a specific experiment (repeatable); omit to track all
+- `--no-auto-update` — pin the context instead of refreshing as new experiments land
+
+## Managing interests
+
+```bash
+remyxai interests list                       # show all your interests
+remyxai interests get <name-or-uuid>         # show one interest's details
+remyxai interests update <id> --context ...  # edit fields
+remyxai interests toggle <id>                # flip active/inactive
+remyxai interests delete <id>                # remove
+```
+
+An inactive interest is excluded from the daily digest until toggled back on. Deleting an interest also removes all its recommendations.
+
+## What the context body looks like
+
+Interests are prompt-anchor artifacts — the recommendation pipeline consumes the context as natural-language framing for the ranker. Good interest contexts:
+
+- Name specific method families ("Quantization, speculative decoding, KV cache compression"), not broad domains ("LLMs")
+- Include the codebase's shape when relevant ("This is a training library; algorithm-add papers implementing new optimizers are the primary target")
+- Explicitly scope out adjacent-but-off-domain areas ("Not interested in general-purpose agent frameworks; only LoRA / PEFT optimizer methods")
+
+`interests from-repo` produces a reasonable context automatically for most repos. Hand-editing via `interests update --context ...` afterward tightens the ranker's picks when the auto-extract is too broad or catches the wrong theme.

--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -785,18 +785,22 @@ def outrider_setup_local(
                   "Target repo as owner/name or a GitHub URL. Defaults to "
                   "detecting from the current directory's git remote."
               ))
-@click.option("--pin-method", "pin_method", default=None,
+@click.option("--search-method", "search_method", default=None,
               help=(
-                  "Method/technique query (e.g. \"knowledge distillation\") "
-                  "or a literal arxiv_id. The action's selection pass is "
-                  "bypassed and the resolved paper is implemented directly. "
-                  "Mutually exclusive with --pin-arxiv."
+                  "Free-text method/technique query (e.g. \"riemannian "
+                  "preconditioning LoRA optimizer\"). Runs an engine "
+                  "search and implements the top hit. Use for "
+                  "exploratory dispatches when you know the method "
+                  "family but not the specific arxiv id. For exact "
+                  "papers, use --pin-arxiv."
               ))
 @click.option("--pin-arxiv", "pin_arxiv", default=None,
               help=(
-                  "arxiv_id of a paper in the repo's candidate pool to "
-                  "implement directly. Use --pin-method for arxiv_ids not "
-                  "in the pool (it does a direct asset lookup)."
+                  "Exact arxiv_id (e.g. 2402.02347v3). Bypasses selection "
+                  "and implements this specific paper. Use for reproducible "
+                  "re-runs. Falls back to Remyx's asset lookup if the id "
+                  "isn't in the ranker's pool, so any published arxiv paper "
+                  "works — not just those the interest surfaces."
               ))
 @click.option("--interest", "-i", "interest_id", default=None,
               help="Override the ResearchInterest UUID for this run.")
@@ -827,40 +831,49 @@ def outrider_setup_local(
                   "which sets ANTHROPIC_MODEL in the action's env. "
                   "Empty = provider picks its default."
               ))
-def outrider_trigger(repo, pin_method, pin_arxiv, interest_id, ref, claude_timeout, provider, model):
+def outrider_trigger(repo, search_method, pin_arxiv, interest_id, ref, claude_timeout, provider, model):
     """
     Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
 
-    Useful for kicking off ad-hoc method-targeted PRs without waiting for
-    the next scheduled run. The repo must already have an Outrider workflow
-    installed (see `remyxai outrider init` / `setup-local`). Authenticates
-    via your local `gh` CLI — no Remyx engine round-trip.
+    Three modes of specificity, in ascending order of override:
+
+    \b
+    - default (no pin): Remyx ranks candidates from the interest-scoped
+      pool + Outrider's audit augments via agentic refine-queries;
+      Claude Code picks the best implementation from the ranked pool.
+    - --search-method: overrides the ranked pool with an engine search
+      on the user-specified query; the top hit gets implemented.
+    - --pin-arxiv: exact arxiv paper; bypasses the pool entirely and
+      implements THIS specific paper against the target branch.
+
+    The repo must already have an Outrider workflow installed (see
+    `remyxai outrider init` / `setup-local`). Authenticates via your
+    local `gh` CLI — no Remyx engine round-trip.
 
     Examples:
 
-      # Implement a specific method on a target repo
-      remyxai outrider trigger --repo owner/name \\
-        --pin-method "knowledge distillation"
+      # Implement a specific paper by arxiv id (exact, reproducible)
+      remyxai outrider trigger --repo owner/name --pin-arxiv 2402.02347v3
 
-      # Re-run a previously surfaced paper by arxiv_id (works even if it's
-      # no longer in the candidate pool)
-      remyxai outrider trigger --repo owner/name --pin-method 2410.20305v2
+      # Exploratory: search for a method-family and implement the top hit
+      remyxai outrider trigger --repo owner/name \\
+        --search-method "riemannian preconditioning LoRA optimizer"
 
       # Route at z.ai's GLM-5.2 for this dispatch (Anthropic is the
       # workflow's default; this overrides for one run)
       remyxai outrider trigger --repo owner/name \\
-        --pin-method 2410.20305v2 --provider zai --model glm-5.2
+        --pin-arxiv 2402.02347v3 --provider zai --model glm-5.2
 
       # Bump the implementation timeout for a very large monorepo
       remyxai outrider trigger --repo owner/name \\
-        --pin-method 2410.20305v2 --claude-timeout 1800
+        --pin-arxiv 2402.02347v3 --claude-timeout 1800
 
       # Plain trigger — let the normal selection pass run
       remyxai outrider trigger --repo owner/name
     """
     handle_outrider_trigger(
         repo=repo,
-        pin_method=pin_method,
+        search_method=search_method,
         pin_arxiv=pin_arxiv,
         interest_id=interest_id,
         ref=ref,

--- a/remyxai/cli/outrider_actions.py
+++ b/remyxai/cli/outrider_actions.py
@@ -565,7 +565,7 @@ def _gh_latest_run_url(repo, sleep=time.sleep):
 
 
 def handle_outrider_trigger(
-    repo, pin_method, pin_arxiv, interest_id, ref, claude_timeout=None,
+    repo, search_method, pin_arxiv, interest_id, ref, claude_timeout=None,
     provider=None, model=None,
 ):
     """Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
@@ -582,9 +582,9 @@ def handle_outrider_trigger(
     (especially when routing at slower non-Anthropic backends).
     """
     # Inputs validation
-    if pin_method and pin_arxiv:
+    if search_method and pin_arxiv:
         raise click.UsageError(
-            "--pin-method and --pin-arxiv are mutually exclusive."
+            "--search-method and --pin-arxiv are mutually exclusive."
         )
     if claude_timeout is not None and claude_timeout < 60:
         raise click.UsageError(
@@ -623,7 +623,7 @@ def handle_outrider_trigger(
         )
 
     inputs = {
-        "pin-method": pin_method or "",
+        "search-method": search_method or "",
         "pin-arxiv": pin_arxiv or "",
         "interest-id": interest_id or "",
         # Forward as a string — workflow_dispatch input values are
@@ -643,8 +643,8 @@ def handle_outrider_trigger(
         click.echo(f"  provider:       {provider}")
     if model:
         click.echo(f"  model:          {model}")
-    if pin_method:
-        click.echo(f"  pin-method:     {pin_method!r}")
+    if search_method:
+        click.echo(f"  search-method:  {search_method!r}")
     if pin_arxiv:
         click.echo(f"  pin-arxiv:      {pin_arxiv!r}")
     if interest_id:
@@ -761,5 +761,5 @@ def handle_set_provider_secret(repo, provider, key_from):
         click.echo(
             "  Next: `remyxai outrider trigger --repo "
             f"{resolved_repo} --provider zai --model glm-5.2 "
-            f"--pin-method <arxiv>` to test."
+            f"--pin-arxiv <arxiv-id>` to test."
         )

--- a/remyxai/cli/outrider_local.py
+++ b/remyxai/cli/outrider_local.py
@@ -293,12 +293,12 @@ on:
         description: 'Specific model name to request from the provider (e.g. claude-opus-4-7, glm-5.2, glm-4.6). Empty = let the provider pick its default.'
         required: false
         default: ''
-      pin-method:
-        description: 'Optional arxiv_id or method query to implement directly (bypasses selection).'
+      search-method:
+        description: 'Optional free-text method query (e.g. "riemannian preconditioning LoRA"). Runs an engine search and implements the top hit. Use for exploratory dispatches.'
         required: false
         default: ''
       pin-arxiv:
-        description: 'Optional arxiv_id from this repo''s candidate pool to implement directly.'
+        description: 'Optional exact arxiv_id (e.g. 2402.02347v3). Bypasses selection and implements this specific paper. Use for reproducible re-runs.'
         required: false
         default: ''
       claude-timeout:
@@ -353,7 +353,7 @@ jobs:
           # can pin a paper, extend the implementation timeout, or
           # route at an alternate provider per dispatch. Empty on
           # scheduled runs — the action uses its own defaults.
-          pin-method: ${{{{ inputs.pin-method }}}}
+          search-method: ${{{{ inputs.search-method }}}}
           pin-arxiv: ${{{{ inputs.pin-arxiv }}}}
           claude-timeout: ${{{{ inputs.claude-timeout }}}}
           # Maps provider name → base URL. Adding more providers here

--- a/tests/cli/test_outrider_local.py
+++ b/tests/cli/test_outrider_local.py
@@ -92,7 +92,7 @@ def test_render_declares_model_input_and_configure_step_sets_env():
 
 
 def test_render_declares_workflow_dispatch_inputs():
-    """The generated workflow exposes pin-method / pin-arxiv /
+    """The generated workflow exposes search-method / pin-arxiv /
     claude-timeout as workflow_dispatch inputs so `remyxai outrider
     trigger` and manual `gh workflow run -f ...` can forward them
     without the workflow rejecting them as 'not a permitted key'."""
@@ -101,7 +101,7 @@ def test_render_declares_workflow_dispatch_inputs():
     assert "workflow_dispatch:" in wf
     assert "    inputs:" in wf
     # Each declared input is present.
-    for name in ("pin-method:", "pin-arxiv:", "claude-timeout:"):
+    for name in ("search-method:", "pin-arxiv:", "claude-timeout:"):
         assert name in wf, f"missing input declaration: {name}"
     # claude-timeout's default matches the action's documented 900s.
     assert "default: '900'" in wf
@@ -111,7 +111,7 @@ def test_render_forwards_workflow_dispatch_inputs_to_action():
     """Each declared workflow_dispatch input is forwarded into the
     action's `with:` block via ${{ inputs.<name> }}."""
     wf = outrider_local._render_local_workflow("uuid")
-    for name in ("pin-method", "pin-arxiv", "claude-timeout"):
+    for name in ("search-method", "pin-arxiv", "claude-timeout"):
         assert f"{name}: ${{{{ inputs.{name} }}}}" in wf, (
             f"missing forwarding for {name}"
         )

--- a/tests/cli/test_outrider_trigger.py
+++ b/tests/cli/test_outrider_trigger.py
@@ -4,7 +4,7 @@ Covers:
 - CLI wiring (option flags, mutex enforcement, click usage errors)
 - Repo resolution (explicit, auto-detect from git, missing)
 - Default ref resolution (from gh API) + explicit ref override
-- gh-dispatch invocation (correct path, ref, pin-method / pin-arxiv inputs)
+- gh-dispatch invocation (correct path, ref, search-method / pin-arxiv inputs)
 - Failure surfacing (404 not-installed, 403 missing-scope)
 - Run-URL best-effort lookup
 
@@ -24,7 +24,7 @@ from remyxai.cli.commands import cli
 # ─── _gh_dispatch_outrider ────────────────────────────────────────────────
 
 
-def test_gh_dispatch_includes_pin_method_input():
+def test_gh_dispatch_includes_search_method_input():
     """Non-empty inputs flow through to `gh workflow run -f <key>=<val>`."""
     captured = {}
 
@@ -35,7 +35,7 @@ def test_gh_dispatch_includes_pin_method_input():
     with patch("subprocess.run", side_effect=fake_run):
         ok, err = outrider_actions._gh_dispatch_outrider(
             "owner/name", "main",
-            {"pin-method": "knowledge distillation", "pin-arxiv": "",
+            {"search-method": "knowledge distillation", "pin-arxiv": "",
              "interest-id": ""},
         )
     assert ok is True
@@ -46,7 +46,7 @@ def test_gh_dispatch_includes_pin_method_input():
     assert "outrider.yml" in args
     assert "--repo" in args and "owner/name" in args
     assert "--ref" in args and "main" in args
-    assert "pin-method=knowledge distillation" in args
+    assert "search-method=knowledge distillation" in args
     # Empty inputs are dropped, not sent as empty strings.
     assert not any(a.startswith("pin-arxiv=") for a in args)
     assert not any(a.startswith("interest-id=") for a in args)
@@ -58,7 +58,7 @@ def test_gh_dispatch_surfaces_stderr_on_failure():
 
     with patch("subprocess.run", side_effect=fake_run):
         ok, err = outrider_actions._gh_dispatch_outrider(
-            "owner/name", "main", {"pin-method": "X"},
+            "owner/name", "main", {"search-method": "X"},
         )
     assert ok is False
     assert "404" in err
@@ -86,11 +86,11 @@ def test_default_branch_none_on_gh_failure():
 # ─── handle_outrider_trigger — high-level flow ────────────────────────────
 
 
-def test_trigger_mutex_pin_method_and_pin_arxiv():
+def test_trigger_mutex_search_method_and_pin_arxiv():
     with pytest.raises(click.UsageError, match="mutually exclusive"):
         outrider_actions.handle_outrider_trigger(
             repo="owner/name",
-            pin_method="X", pin_arxiv="2410.20305v2",
+            search_method="X", pin_arxiv="2410.20305v2",
             interest_id=None, ref=None,
         )
 
@@ -100,7 +100,7 @@ def test_trigger_errors_when_no_repo_and_not_in_git_checkout(monkeypatch):
                         lambda: None)
     with pytest.raises(click.UsageError, match="Could not determine target repo"):
         outrider_actions.handle_outrider_trigger(
-            repo=None, pin_method="X", pin_arxiv=None,
+            repo=None, search_method="X", pin_arxiv=None,
             interest_id=None, ref=None,
         )
 
@@ -120,7 +120,7 @@ def test_trigger_refuses_when_workflow_not_installed(monkeypatch):
 
     with pytest.raises(click.ClickException) as exc:
         outrider_actions.handle_outrider_trigger(
-            repo="owner/name", pin_method="X", pin_arxiv=None,
+            repo="owner/name", search_method="X", pin_arxiv=None,
             interest_id=None, ref=None,
         )
     msg = exc.value.message.lower()
@@ -138,13 +138,13 @@ def test_trigger_403_surfaces_scope_hint(monkeypatch):
 
     with pytest.raises(click.ClickException) as exc:
         outrider_actions.handle_outrider_trigger(
-            repo="owner/name", pin_method="X", pin_arxiv=None,
+            repo="owner/name", search_method="X", pin_arxiv=None,
             interest_id=None, ref=None,
         )
     assert "scope" in exc.value.message.lower()
 
 
-def test_trigger_happy_path_with_pin_method(monkeypatch, capsys):
+def test_trigger_happy_path_with_search_method(monkeypatch, capsys):
     captured_dispatch = {}
 
     def fake_dispatch(repo, branch, inputs):
@@ -163,13 +163,13 @@ def test_trigger_happy_path_with_pin_method(monkeypatch, capsys):
                         "https://github.com/owner/name/actions/runs/123")
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="knowledge distillation",
+        repo="owner/name", search_method="knowledge distillation",
         pin_arxiv=None, interest_id=None, ref=None,
     )
 
     assert captured_dispatch["repo"] == "owner/name"
     assert captured_dispatch["branch"] == "main"
-    assert captured_dispatch["inputs"]["pin-method"] == "knowledge distillation"
+    assert captured_dispatch["inputs"]["search-method"] == "knowledge distillation"
     assert captured_dispatch["inputs"]["pin-arxiv"] == ""
 
     out = capsys.readouterr().out
@@ -193,7 +193,7 @@ def test_trigger_uses_explicit_ref(monkeypatch):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref="release/v2",
     )
     assert seen["branch"] == "release/v2"
@@ -219,7 +219,7 @@ def test_outrider_workflow_exists_false_on_404():
 # ─── CLI integration via click runner ─────────────────────────────────────
 
 
-def test_cli_outrider_trigger_pin_method(monkeypatch):
+def test_cli_outrider_trigger_search_method(monkeypatch):
     monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
                         lambda repo: True)
     monkeypatch.setattr(outrider_actions, "_gh_default_branch",
@@ -233,11 +233,11 @@ def test_cli_outrider_trigger_pin_method(monkeypatch):
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "knowledge distillation",
+        "--search-method", "knowledge distillation",
     ])
     assert result.exit_code == 0, result.output
     assert "Dispatched" in result.output
-    assert "pin-method" in result.output
+    assert "search-method" in result.output
 
 
 def test_cli_outrider_trigger_mutex_via_click():
@@ -245,7 +245,7 @@ def test_cli_outrider_trigger_mutex_via_click():
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "X", "--pin-arxiv", "2410.20305v2",
+        "--search-method", "X", "--pin-arxiv", "2410.20305v2",
     ])
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output.lower()
@@ -271,7 +271,7 @@ def test_trigger_forwards_claude_timeout_when_set(monkeypatch, capsys):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None, claude_timeout=1800,
     )
     # Stringified at the dispatch boundary because workflow_dispatch
@@ -299,7 +299,7 @@ def test_trigger_omits_claude_timeout_when_unset(monkeypatch):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None,
     )
     assert captured["inputs"]["claude-timeout"] == ""
@@ -310,7 +310,7 @@ def test_trigger_rejects_claude_timeout_below_minimum():
     waiting for the action to fail on a too-tight ceiling."""
     with pytest.raises(click.UsageError, match="at least 60 seconds"):
         outrider_actions.handle_outrider_trigger(
-            repo="owner/name", pin_method="X", pin_arxiv=None,
+            repo="owner/name", search_method="X", pin_arxiv=None,
             interest_id=None, ref=None, claude_timeout=30,
         )
 
@@ -335,7 +335,7 @@ def test_cli_claude_timeout_flag_accepted_and_dispatched(monkeypatch):
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "2410.20305v2",
+        "--search-method", "2410.20305v2",
         "--claude-timeout", "2700",
     ])
     assert result.exit_code == 0, result.output
@@ -349,7 +349,7 @@ def test_cli_claude_timeout_must_be_integer():
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "X",
+        "--search-method", "X",
         "--claude-timeout", "nope",
     ])
     assert result.exit_code != 0
@@ -376,7 +376,7 @@ def test_trigger_forwards_provider_when_set(monkeypatch, capsys):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None, provider="zai",
     )
     assert captured["inputs"]["provider"] == "zai"
@@ -402,7 +402,7 @@ def test_trigger_omits_provider_when_unset(monkeypatch):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None,
     )
     assert captured["inputs"]["provider"] == ""
@@ -428,7 +428,7 @@ def test_cli_provider_flag_dispatched(monkeypatch):
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "2410.20305v2",
+        "--search-method", "2410.20305v2",
         "--provider", "anthropic",
     ])
     assert result.exit_code == 0, result.output
@@ -457,14 +457,14 @@ def test_cli_provider_combines_with_claude_timeout(monkeypatch):
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "2410.20305v2",
+        "--search-method", "2410.20305v2",
         "--provider", "zai",
         "--claude-timeout", "1200",
     ])
     assert result.exit_code == 0, result.output
     assert captured["inputs"]["provider"] == "zai"
     assert captured["inputs"]["claude-timeout"] == "1200"
-    assert captured["inputs"]["pin-method"] == "2410.20305v2"
+    assert captured["inputs"]["search-method"] == "2410.20305v2"
 
 
 # ─── --model forwarding ───────────────────────────────────────────────────
@@ -487,7 +487,7 @@ def test_trigger_forwards_model_when_set(monkeypatch, capsys):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None, provider="zai", model="glm-5.2",
     )
     assert captured["inputs"]["model"] == "glm-5.2"
@@ -513,14 +513,14 @@ def test_trigger_omits_model_when_unset(monkeypatch):
                         lambda repo, sleep=None: None)
 
     outrider_actions.handle_outrider_trigger(
-        repo="owner/name", pin_method="X", pin_arxiv=None,
+        repo="owner/name", search_method="X", pin_arxiv=None,
         interest_id=None, ref=None,
     )
     assert captured["inputs"]["model"] == ""
 
 
 def test_cli_model_combines_with_provider(monkeypatch):
-    """End-to-end through click: --provider + --model + --pin-method
+    """End-to-end through click: --provider + --model + --search-method
     all reach the dispatch payload together."""
     captured = {}
 
@@ -540,7 +540,7 @@ def test_cli_model_combines_with_provider(monkeypatch):
     result = runner.invoke(cli, [
         "outrider", "trigger",
         "--repo", "owner/name",
-        "--pin-method", "2410.20305v2",
+        "--search-method", "2410.20305v2",
         "--provider", "zai",
         "--model", "glm-4.6",
         "--claude-timeout", "1500",


### PR DESCRIPTION
Coordinates with outrider v1.7.7's `pin-method` → `search-method` input rename.

## CLI changes

- Hard rename `--pin-method` → `--search-method`. No deprecation shim — early adoption.
- Three-tier framing in the `outrider trigger` docstring: default (ranked pool) → `--search-method` (query override) → `--pin-arxiv` (exact).
- Workflow template (`outrider_local.py`) emits `search-method:` as the workflow_dispatch input.

## Docs restructure

- README trimmed from 183 → 57 lines. Grep-friendly at the top level.
- Content pushed to `docs/`: pipeline explanation, research-interests flavors, method-targeted runs (extended with team-scale patterns), full command reference.