### PR TITLE
outrider setup-local: --two-tier flag with live-fetched templates

### DIFF
--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -715,6 +715,31 @@ def outrider_init(
                   "remyxai/outrider@v1 at install time. See remyxai/outrider "
                   "docs/customization.md §5 for the design rationale."
               ))
+@click.option("--drafter-model", "drafter_model", default=None,
+              help=(
+                  "Optional model for the two-tier drafter (outrider-daily.yml). "
+                  "e.g. glm-5.2, claude-sonnet-4-6. A GLM model routes the stage "
+                  "at z.ai (needs a ZAI_API_KEY). Omit to keep the single-provider "
+                  "default (Haiku 4.5). Requires --two-tier."
+              ))
+@click.option("--refiner-model", "refiner_model", default=None,
+              help=(
+                  "Optional model for the two-tier refiner's gap-analysis call "
+                  "(outrider-weekly-refine.yml). GLM routes at z.ai. Omit for the "
+                  "default (Sonnet 4.6). Requires --two-tier."
+              ))
+@click.option("--refine-model", "refine_model", default=None,
+              help=(
+                  "Optional model the refiner dispatches for the final refinement "
+                  "run. GLM routes at z.ai (via the runner's provider mapping). "
+                  "Omit for the default (Opus 4.8). Requires --two-tier."
+              ))
+@click.option("--zai-key", "zai_key", default=None,
+              help=(
+                  "z.ai GLM Coding Plan API key, set as the ZAI_API_KEY repo "
+                  "secret. Only needed when a --*-model selects a GLM model; "
+                  "falls back to $ZAI_API_KEY / $Z_AI_KEY, else prompts."
+              ))
 @click.option("--bulk-repos", "bulk_repos", type=click.Path(), default=None,
               help=(
                   "Path to a TSV mapping repos to ResearchInterest UUIDs "
@@ -730,7 +755,8 @@ def outrider_init(
               help="Skip the confirmation prompt (default is opt-in).")
 def outrider_setup_local(
     repo, interest_id, auto_interest, mode, anthropic_key,
-    no_cron, no_cocoindex, two_tier, bulk_repos, pace_s, dry_run, skip_confirm,
+    no_cron, no_cocoindex, two_tier, drafter_model, refiner_model, refine_model,
+    zai_key, bulk_repos, pace_s, dry_run, skip_confirm,
 ):
     """
     Set up Outrider WITHOUT the Remyx GitHub App.
@@ -776,6 +802,10 @@ def outrider_setup_local(
                 no_cron=no_cron,
                 no_cocoindex=no_cocoindex,
                 two_tier=two_tier,
+                drafter_model=drafter_model,
+                refiner_model=refiner_model,
+                refine_model=refine_model,
+                zai_key=zai_key,
             ),
             pace_s=pace_s,
         )
@@ -791,6 +821,10 @@ def outrider_setup_local(
         no_cron=no_cron,
         no_cocoindex=no_cocoindex,
         two_tier=two_tier,
+        drafter_model=drafter_model,
+        refiner_model=refiner_model,
+        refine_model=refine_model,
+        zai_key=zai_key,
     )
 
 

--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -702,6 +702,19 @@ def outrider_init(
                   "call-site claims on real paths. See outrider's "
                   "docs/environments.md for the rationale."
               ))
+@click.option("--two-tier", "two_tier", is_flag=True, default=False,
+              help=(
+                  "Install the two-tier drafter/refiner setup (recommended "
+                  "default for repos where continuous exploration + weekly "
+                  "promotion is wanted). Writes outrider-daily.yml (drafter, "
+                  "Anthropic Haiku 4.5, publish=branch, daily cron) and "
+                  "outrider-weekly-refine.yml (refiner orchestrator, weekly "
+                  "cron, picks candidate + generates gap analysis via Sonnet "
+                  "4.6 + dispatches Opus refinement) alongside a manual-"
+                  "dispatch outrider.yml. Templates are fetched from "
+                  "remyxai/outrider@v1 at install time. See remyxai/outrider "
+                  "docs/customization.md §5 for the design rationale."
+              ))
 @click.option("--bulk-repos", "bulk_repos", type=click.Path(), default=None,
               help=(
                   "Path to a TSV mapping repos to ResearchInterest UUIDs "
@@ -717,7 +730,7 @@ def outrider_init(
               help="Skip the confirmation prompt (default is opt-in).")
 def outrider_setup_local(
     repo, interest_id, auto_interest, mode, anthropic_key,
-    no_cron, no_cocoindex, bulk_repos, pace_s, dry_run, skip_confirm,
+    no_cron, no_cocoindex, two_tier, bulk_repos, pace_s, dry_run, skip_confirm,
 ):
     """
     Set up Outrider WITHOUT the Remyx GitHub App.
@@ -762,6 +775,7 @@ def outrider_setup_local(
                 dry_run=dry_run,
                 no_cron=no_cron,
                 no_cocoindex=no_cocoindex,
+                two_tier=two_tier,
             ),
             pace_s=pace_s,
         )
@@ -776,6 +790,7 @@ def outrider_setup_local(
         dry_run=dry_run,
         no_cron=no_cron,
         no_cocoindex=no_cocoindex,
+        two_tier=two_tier,
     )
 
 

--- a/remyxai/cli/outrider_local.py
+++ b/remyxai/cli/outrider_local.py
@@ -307,6 +307,31 @@ on:
         description: 'Optional exact arxiv_id (e.g. 2402.02347v3). Bypasses selection and implements this specific paper. Use for reproducible re-runs.'
         required: false
         default: ''
+      # The five inputs below let outrider-weekly-refine.yml (the refiner)
+      # dispatch this runner: it pins the picked draft branch (start-from-ref),
+      # pipes a gap analysis in (lead-content), turns on staged synthesis, and
+      # selects mode/publish. Defaults match the action's own, so scheduled and
+      # manual runs are unchanged.
+      mode:
+        description: 'Run mode. recommend (default) runs the full scout→implement flow; the refiner dispatches recommend against a pinned paper + start-from-ref.'
+        required: false
+        default: 'recommend'
+      publish:
+        description: 'pr (default) opens a PR/Issue; branch produces a fork branch without opening one (drafter behavior).'
+        required: false
+        default: 'pr'
+      start-from-ref:
+        description: 'Optional base branch to build on top of (the refiner passes the picked drafter branch here). Empty = start from the default branch.'
+        required: false
+        default: ''
+      lead-content:
+        description: 'Optional inline markdown (e.g. a gap analysis) fed to the agent as leading context. Used by the refiner dispatch.'
+        required: false
+        default: ''
+      staged-synthesis:
+        description: 'Enable the multi-pass staged-synthesis flow (the refiner sets true). Empty/false = single-pass.'
+        required: false
+        default: 'false'
       claude-timeout:
         description: 'Wall-clock seconds for the Claude Code agent calls (preflight + implementation). Raise for very large monorepos; lower to cap cost.'
         required: false
@@ -362,6 +387,14 @@ jobs:
           search-method: ${{{{ inputs.search-method }}}}
           pin-arxiv: ${{{{ inputs.pin-arxiv }}}}
           claude-timeout: ${{{{ inputs.claude-timeout }}}}
+          # Forwarded so outrider-weekly-refine.yml can dispatch a refinement
+          # run (mode + start-from-ref + lead-content + staged-synthesis) and
+          # so the drafter/manual runs can pick pr vs branch publishing.
+          mode: ${{{{ inputs.mode }}}}
+          publish: ${{{{ inputs.publish }}}}
+          start-from-ref: ${{{{ inputs.start-from-ref }}}}
+          lead-content: ${{{{ inputs.lead-content }}}}
+          staged-synthesis: ${{{{ inputs.staged-synthesis }}}}
           # Maps provider name → base URL. Adding more providers here
           # extends the table (Bedrock / Vertex / on-prem); leave
           # empty on the default Anthropic path.
@@ -394,6 +427,13 @@ _REFINER_TEMPLATE_PATH = ".github/workflows/outrider-weekly-refine.yml"
 # We rewrite that specific string to the customer's interest-id at render time.
 _OUTRIDER_SELF_INTEREST_ID = "29ca03e7-454d-446c-9941-32c96c53d95d"
 
+# The outrider repo's templates reference the action locally (``uses: ./``),
+# which only resolves from inside the outrider repo itself. On a customer
+# install that path points at the target repo's root (no action.yml there),
+# so we rewrite it to the published action ref at render time.
+_LOCAL_ACTION_USES = "uses: ./"
+_PUBLISHED_ACTION_USES = f"uses: {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF}"
+
 
 def _fetch_outrider_template(path: str) -> str:
     """Fetch a workflow-template file from remyxai/outrider@v1 via `gh api`.
@@ -404,7 +444,7 @@ def _fetch_outrider_template(path: str) -> str:
     import base64
     try:
         payload = _gh_api_json([
-            "api", f"repos/{_OUTRIDER_TEMPLATE_REPO}/contents/{path}?ref={_OUTRIDER_TEMPLATE_REF}",
+            f"repos/{_OUTRIDER_TEMPLATE_REPO}/contents/{path}?ref={_OUTRIDER_TEMPLATE_REF}",
         ])
     except Exception as e:
         raise click.ClickException(
@@ -421,7 +461,8 @@ def _fetch_outrider_template(path: str) -> str:
 
 def _render_drafter_workflow(interest_id: str) -> str:
     """Drafter template — fetched live from remyxai/outrider@v1 with the
-    self-test interest-id rewritten to the customer's."""
+    self-test interest-id rewritten to the customer's and the local action
+    reference (``uses: ./``) rewritten to the published action ref."""
     raw = _fetch_outrider_template(_DRAFTER_TEMPLATE_PATH)
     if _OUTRIDER_SELF_INTEREST_ID not in raw:
         raise click.ClickException(
@@ -430,7 +471,16 @@ def _render_drafter_workflow(interest_id: str) -> str:
             f"({_OUTRIDER_SELF_INTEREST_ID}); template format may have changed. "
             f"CLI needs an update."
         )
-    return raw.replace(_OUTRIDER_SELF_INTEREST_ID, interest_id)
+    if _LOCAL_ACTION_USES not in raw:
+        raise click.ClickException(
+            f"drafter template on {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF} "
+            f"no longer references the action via '{_LOCAL_ACTION_USES}'; template "
+            f"format may have changed. CLI needs an update."
+        )
+    return (
+        raw.replace(_OUTRIDER_SELF_INTEREST_ID, interest_id)
+           .replace(_LOCAL_ACTION_USES, _PUBLISHED_ACTION_USES)
+    )
 
 
 def _render_refiner_workflow() -> str:
@@ -506,6 +556,9 @@ def handle_outrider_setup_local(
         click.echo(f"               {DRAFTER_WORKFLOW_PATH} (daily drafter, Haiku 4.5, publish=branch)")
         click.echo(f"               {REFINER_WORKFLOW_PATH} (weekly refiner, picks + gap-gens + dispatches Opus)")
         click.echo("               (three files on a branch → one PR — templates fetched live from remyxai/outrider@v1)")
+        click.secho("  - Note:      forks don't run scheduled workflows — the daily/weekly "
+                    "crons need an external dispatcher on a fork (workflow_dispatch is unaffected).",
+                    fg="yellow")
     else:
         click.echo(f"  - Writes:    {WORKFLOW_PATH} on a branch + opens a PR")
     click.echo("")
@@ -597,8 +650,22 @@ def handle_outrider_setup_local(
             f"Research interest: `{resolved_interest}`\n\n"
             f"Generated by `remyxai outrider setup-local`."
         )
+        if two_tier:
+            body += (
+                "\n\n**Two-tier setup** — installs a daily drafter "
+                "(`outrider-daily.yml`) and a weekly refiner "
+                "(`outrider-weekly-refine.yml`) alongside the manual-dispatch "
+                "runner.\n\n"
+                "> **Note — forks:** GitHub disables/deprioritizes `schedule:` "
+                "triggers on forked repos, so the drafter's daily cron and the "
+                "refiner's weekly cron will not self-run on a fork. "
+                "`workflow_dispatch` (manual / `gh workflow run`) works either "
+                "way; drive the cadence from an external dispatcher if this repo "
+                "is a fork."
+            )
         pr_url, pr_number = _gh_open_pr(
-            resolved_repo, branch_name, default_branch, PR_TITLE, body,
+            resolved_repo, branch_name, default_branch,
+            PR_TITLE_TWO_TIER if two_tier else PR_TITLE, body,
             draft=(mode != "auto"),
         )
         click.echo(f"✓ Opened PR: {pr_url}")

--- a/remyxai/cli/outrider_local.py
+++ b/remyxai/cli/outrider_local.py
@@ -434,6 +434,102 @@ _OUTRIDER_SELF_INTEREST_ID = "29ca03e7-454d-446c-9941-32c96c53d95d"
 _LOCAL_ACTION_USES = "uses: ./"
 _PUBLISHED_ACTION_USES = f"uses: {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF}"
 
+# ─── optional per-stage model overrides ─────────────────────────────────────
+#
+# By default the two-tier templates are single-provider (all three stages run
+# on Anthropic) so an install needs only ANTHROPIC_API_KEY. The optional
+# --drafter-model / --refiner-model / --refine-model flags let a caller retune
+# any stage — including routing it at z.ai's GLM — without hand-editing the
+# installed workflow files. Provider is inferred from the model name: GLM
+# models route at z.ai (Bearer auth via ZAI_API_KEY), everything else stays on
+# Anthropic. See remyxai/outrider docs/backends.md for the routing details.
+
+_ZAI_BASE_URL = "https://api.z.ai/api/anthropic"
+
+# Structural anchors in the @v1 templates that the overrides rewrite. Kept as
+# explicit constants so a template shape change fails loud (matching the
+# interest-id / uses-./ guards) rather than silently skipping a rewrite.
+_DRAFTER_ANTHROPIC_ENV = "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}"
+_DRAFTER_ZAI_ENV = "ANTHROPIC_AUTH_TOKEN: ${{ secrets.ZAI_API_KEY }}"
+_DRAFTER_PUBLISH_ANCHOR = "publish: branch"
+_GAP_ANTHROPIC_URL = '"https://api.anthropic.com/v1/messages"'
+_GAP_ZAI_URL = '"https://api.z.ai/api/anthropic/v1/messages"'
+_GAP_ANTHROPIC_AUTH = '"x-api-key": os.environ["ANTHROPIC_API_KEY"],'
+_GAP_ZAI_AUTH = '"Authorization": f"Bearer {os.environ[\'ZAI_API_KEY\']}",'
+_GAP_ENV_ANCHOR = "REPO: ${{ github.repository }}"
+
+
+def _provider_for_model(model: str) -> str:
+    """Infer the backend provider from a model name. GLM models route at z.ai;
+    everything else (claude-*) uses the default Anthropic API."""
+    return "zai" if model.lower().startswith("glm") else "anthropic"
+
+
+def uses_zai(*models) -> bool:
+    """True if any supplied (non-empty) model resolves to the z.ai provider —
+    i.e. the install needs a ZAI_API_KEY secret."""
+    return any(m and _provider_for_model(m) == "zai" for m in models)
+
+
+def _require_anchor(text: str, anchor: str, what: str) -> None:
+    if anchor not in text:
+        raise click.ClickException(
+            f"{what} template on {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF} "
+            f"no longer contains the expected anchor ({anchor!r}); template format "
+            f"may have changed. CLI needs an update (or drop the model override)."
+        )
+
+
+def _apply_drafter_model(text: str, model: str) -> str:
+    """Rewrite the drafter's model (and, for GLM, its provider auth + base URL)."""
+    import re
+    _require_anchor(text, "ANTHROPIC_MODEL:", "drafter")
+    text = re.sub(r"(?m)^(\s*)ANTHROPIC_MODEL:.*$", rf"\g<1>ANTHROPIC_MODEL: {model}", text)
+    if _provider_for_model(model) == "zai":
+        # z.ai needs Bearer auth; ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN are
+        # mutually exclusive, so swap the env var rather than adding one.
+        _require_anchor(text, _DRAFTER_ANTHROPIC_ENV, "drafter")
+        _require_anchor(text, _DRAFTER_PUBLISH_ANCHOR, "drafter")
+        text = text.replace(_DRAFTER_ANTHROPIC_ENV, _DRAFTER_ZAI_ENV)
+        text = text.replace(
+            _DRAFTER_PUBLISH_ANCHOR,
+            f"{_DRAFTER_PUBLISH_ANCHOR}\n          model-base-url: {_ZAI_BASE_URL}",
+            1,
+        )
+    return text
+
+
+def _apply_refiner_gap_model(text: str, model: str) -> str:
+    """Rewrite the refiner's gap-analysis LLM call (model, and for GLM the
+    endpoint + Bearer auth + ZAI_API_KEY step env)."""
+    import re
+    _require_anchor(text, '"model":', "refiner")
+    text = re.sub(r'"model": "[^"]*"', f'"model": "{model}"', text, count=1)
+    if _provider_for_model(model) == "zai":
+        _require_anchor(text, _GAP_ANTHROPIC_URL, "refiner")
+        _require_anchor(text, _GAP_ANTHROPIC_AUTH, "refiner")
+        _require_anchor(text, _GAP_ENV_ANCHOR, "refiner")
+        text = text.replace(_GAP_ANTHROPIC_URL, _GAP_ZAI_URL)
+        text = text.replace(_GAP_ANTHROPIC_AUTH, _GAP_ZAI_AUTH)
+        text = text.replace(
+            _GAP_ENV_ANCHOR,
+            f"{_GAP_ENV_ANCHOR}\n          ZAI_API_KEY: ${{{{ secrets.ZAI_API_KEY }}}}",
+            1,
+        )
+    return text
+
+
+def _apply_refine_dispatch_model(text: str, model: str) -> str:
+    """Rewrite the model + provider the refiner dispatches for the final run.
+    The installed runner already maps provider=zai → z.ai base URL, so only the
+    two dispatch flags need changing here."""
+    import re
+    _require_anchor(text, "-f model=", "refiner")
+    _require_anchor(text, "-f provider=", "refiner")
+    text = re.sub(r"-f model=\S+", f"-f model={model}", text, count=1)
+    text = re.sub(r"-f provider=\S+", f"-f provider={_provider_for_model(model)}", text, count=1)
+    return text
+
 
 def _fetch_outrider_template(path: str) -> str:
     """Fetch a workflow-template file from remyxai/outrider@v1 via `gh api`.
@@ -459,10 +555,14 @@ def _fetch_outrider_template(path: str) -> str:
     return base64.b64decode(content_b64).decode()
 
 
-def _render_drafter_workflow(interest_id: str) -> str:
+def _render_drafter_workflow(interest_id: str, model: Optional[str] = None) -> str:
     """Drafter template — fetched live from remyxai/outrider@v1 with the
     self-test interest-id rewritten to the customer's and the local action
-    reference (``uses: ./``) rewritten to the published action ref."""
+    reference (``uses: ./``) rewritten to the published action ref.
+
+    ``model`` (optional) retunes the drafter's model; a GLM model also switches
+    it to z.ai Bearer auth. Omitted → the template's single-provider default.
+    """
     raw = _fetch_outrider_template(_DRAFTER_TEMPLATE_PATH)
     if _OUTRIDER_SELF_INTEREST_ID not in raw:
         raise click.ClickException(
@@ -477,19 +577,33 @@ def _render_drafter_workflow(interest_id: str) -> str:
             f"no longer references the action via '{_LOCAL_ACTION_USES}'; template "
             f"format may have changed. CLI needs an update."
         )
-    return (
+    out = (
         raw.replace(_OUTRIDER_SELF_INTEREST_ID, interest_id)
            .replace(_LOCAL_ACTION_USES, _PUBLISHED_ACTION_USES)
     )
+    if model:
+        out = _apply_drafter_model(out, model)
+    return out
 
 
-def _render_refiner_workflow() -> str:
-    """Refiner template — fetched live from remyxai/outrider@v1 verbatim.
+def _render_refiner_workflow(
+    gap_model: Optional[str] = None, refine_model: Optional[str] = None,
+) -> str:
+    """Refiner template — fetched live from remyxai/outrider@v1.
 
     The refiner has no interest-id substitution point; it dispatches
     outrider.yml (via workflow_dispatch) which reads its own interest-id.
+
+    ``gap_model`` (optional) retunes the gap-analysis LLM call; ``refine_model``
+    (optional) retunes the model/provider the refiner dispatches for the final
+    refinement run. Both omitted → the template's single-provider defaults.
     """
-    return _fetch_outrider_template(_REFINER_TEMPLATE_PATH)
+    out = _fetch_outrider_template(_REFINER_TEMPLATE_PATH)
+    if gap_model:
+        out = _apply_refiner_gap_model(out, gap_model)
+    if refine_model:
+        out = _apply_refine_dispatch_model(out, refine_model)
+    return out
 
 
 # ─── main handler ──────────────────────────────────────────────────────────
@@ -498,6 +612,7 @@ def handle_outrider_setup_local(
     repo, interest_id, auto_interest, mode,
     anthropic_key, skip_confirm, dry_run, no_cron=False, no_cocoindex=False,
     two_tier=False,
+    drafter_model=None, refiner_model=None, refine_model=None, zai_key=None,
 ):
     """Self-provision Outrider with the user's own gh token (no Remyx App).
 
@@ -519,6 +634,13 @@ def handle_outrider_setup_local(
             "--interest and --auto-interest are mutually exclusive."
         )
 
+    # Per-stage model overrides only apply to the two-tier drafter/refiner.
+    if (drafter_model or refiner_model or refine_model) and not two_tier:
+        raise click.UsageError(
+            "--drafter-model / --refiner-model / --refine-model require --two-tier."
+        )
+    need_zai = uses_zai(drafter_model, refiner_model, refine_model)
+
     # 1. REMYX key (set as a repo secret + used to resolve the interest)
     remyx_key = os.environ.get("REMYXAI_API_KEY") or click.prompt(
         "REMYXAI_API_KEY (from engine.remyx.ai Settings)", hide_input=True
@@ -535,6 +657,19 @@ def handle_outrider_setup_local(
     if not anthropic_key.strip():
         raise click.ClickException("ANTHROPIC_API_KEY is required for the workflow.")
 
+    # 2b. z.ai key — only when a stage was routed at GLM (set as a repo secret).
+    if need_zai:
+        zai_key = zai_key or os.environ.get("ZAI_API_KEY") or os.environ.get("Z_AI_KEY")
+        if not zai_key:
+            zai_key = click.prompt(
+                "ZAI_API_KEY (z.ai GLM Coding Plan) — a GLM model was selected",
+                hide_input=True,
+            )
+        if not zai_key.strip():
+            raise click.ClickException(
+                "ZAI_API_KEY is required when any stage uses a GLM model."
+            )
+
     # 3. Repo
     resolved_repo = _normalize_repo(repo) if repo else _detect_github_repo_from_cwd()
     if not resolved_repo:
@@ -548,13 +683,17 @@ def handle_outrider_setup_local(
     click.echo("Plan (no Remyx GitHub App — uses your gh credentials):")
     click.echo(f"  - Repo:      {resolved_repo}")
     click.echo(f"  - Mode:      {mode} (auto = open + merge PR + dispatch; review = open PR only)")
-    click.echo(f"  - Secrets:   REMYX_API_KEY, ANTHROPIC_API_KEY")
+    secrets_line = "REMYX_API_KEY, ANTHROPIC_API_KEY" + (", ZAI_API_KEY" if need_zai else "")
+    click.echo(f"  - Secrets:   {secrets_line}")
     click.echo("  - PR auth:   enable the repo 'Actions can create PRs' setting "
                "(PRs by github-actions[bot])")
     if two_tier:
+        drafter_desc = f"model={drafter_model} ({_provider_for_model(drafter_model)})" if drafter_model else "Haiku 4.5"
+        refiner_desc = f"gap={refiner_model} ({_provider_for_model(refiner_model)})" if refiner_model else "Sonnet gap-analysis"
+        refine_desc = f"model={refine_model} ({_provider_for_model(refine_model)})" if refine_model else "dispatches Opus"
         click.echo(f"  - Writes:    {WORKFLOW_PATH} (manual dispatch, no cron)")
-        click.echo(f"               {DRAFTER_WORKFLOW_PATH} (daily drafter, Haiku 4.5, publish=branch)")
-        click.echo(f"               {REFINER_WORKFLOW_PATH} (weekly refiner, picks + gap-gens + dispatches Opus)")
+        click.echo(f"               {DRAFTER_WORKFLOW_PATH} (daily drafter, {drafter_desc}, publish=branch)")
+        click.echo(f"               {REFINER_WORKFLOW_PATH} (weekly refiner, {refiner_desc}, {refine_desc})")
         click.echo("               (three files on a branch → one PR — templates fetched live from remyxai/outrider@v1)")
         click.secho("  - Note:      forks don't run scheduled workflows — the daily/weekly "
                     "crons need an external dispatcher on a fork (workflow_dispatch is unaffected).",
@@ -570,9 +709,11 @@ def handle_outrider_setup_local(
                 "<interest-id>", no_cron=True, no_cocoindex=no_cocoindex,
             ))
             click.echo("\n--- rendered outrider-daily.yml (drafter) ---")
-            click.echo(_render_drafter_workflow("<interest-id>"))
+            click.echo(_render_drafter_workflow("<interest-id>", model=drafter_model))
             click.echo("\n--- rendered outrider-weekly-refine.yml (refiner) ---")
-            click.echo(_render_refiner_workflow())
+            click.echo(_render_refiner_workflow(
+                gap_model=refiner_model, refine_model=refine_model,
+            ))
         else:
             click.echo("--- rendered workflow ---")
             click.echo(_render_local_workflow(
@@ -630,14 +771,16 @@ def handle_outrider_setup_local(
         click.echo(f"✓ Wrote {WORKFLOW_PATH}")
 
         if two_tier:
-            drafter_yml = _render_drafter_workflow(resolved_interest)
+            drafter_yml = _render_drafter_workflow(resolved_interest, model=drafter_model)
             _gh_put_file(
                 resolved_repo, branch_name, DRAFTER_WORKFLOW_PATH, drafter_yml,
                 "Install Outrider two-tier drafter (self-provisioned)",
             )
             click.echo(f"✓ Wrote {DRAFTER_WORKFLOW_PATH}")
 
-            refiner_yml = _render_refiner_workflow()
+            refiner_yml = _render_refiner_workflow(
+                gap_model=refiner_model, refine_model=refine_model,
+            )
             _gh_put_file(
                 resolved_repo, branch_name, REFINER_WORKFLOW_PATH, refiner_yml,
                 "Install Outrider two-tier refiner (self-provisioned)",
@@ -679,6 +822,9 @@ def handle_outrider_setup_local(
         click.echo("✓ Set REMYX_API_KEY")
         _gh_set_secret(resolved_repo, "ANTHROPIC_API_KEY", anthropic_key)
         click.echo("✓ Set ANTHROPIC_API_KEY")
+        if need_zai:
+            _gh_set_secret(resolved_repo, "ZAI_API_KEY", zai_key)
+            click.echo("✓ Set ZAI_API_KEY")
     except Exception as e:
         if pr_number is not None:
             click.echo(f"  ↩ rolling back: closing PR #{pr_number}", err=True)

--- a/remyxai/cli/outrider_local.py
+++ b/remyxai/cli/outrider_local.py
@@ -40,7 +40,13 @@ logger = logging.getLogger(__name__)
 
 WORKFLOW_FILENAME = "outrider.yml"
 WORKFLOW_PATH = f".github/workflows/{WORKFLOW_FILENAME}"
+
+# Two-tier setup paths — companions to WORKFLOW_PATH under --two-tier.
+DRAFTER_WORKFLOW_PATH = ".github/workflows/outrider-daily.yml"
+REFINER_WORKFLOW_PATH = ".github/workflows/outrider-weekly-refine.yml"
+
 PR_TITLE = "Install Outrider — weekly arXiv → recommendation PRs"
+PR_TITLE_TWO_TIER = "Install Outrider (two-tier drafter/refiner setup)"
 
 
 # ─── gh helpers ─────────────────────────────────────────────────────────────
@@ -363,13 +369,99 @@ jobs:
 """
 
 
+# ─── two-tier templates (drafter + refiner) ────────────────────────────────
+#
+# When ``--two-tier`` is set on ``setup-local``, the CLI fetches the drafter +
+# refiner templates from ``remyxai/outrider@v1`` at install time rather than
+# embedding them inline. This treats the outrider repo as the canonical source
+# of truth for the workflow shape — bugfixes to the picker heuristic, updates
+# to the gap-analysis prompt, changes to the model tier defaults, all land on
+# the outrider repo first and propagate to new customer installs automatically
+# without requiring a CLI release.
+#
+# The drafter template has one substitution point (the ``interest-id``); the
+# refiner has none (it dispatches outrider.yml which reads interest-id from
+# its own configuration).
+#
+# See remyxai/outrider docs/customization.md §5 for the design rationale.
+
+_OUTRIDER_TEMPLATE_REPO = "remyxai/outrider"
+_OUTRIDER_TEMPLATE_REF = "v1"  # moves with each Outrider action release
+_DRAFTER_TEMPLATE_PATH = ".github/workflows/outrider-daily.yml"
+_REFINER_TEMPLATE_PATH = ".github/workflows/outrider-weekly-refine.yml"
+
+# The outrider repo's own drafter has a hardcoded interest-id for its self-test.
+# We rewrite that specific string to the customer's interest-id at render time.
+_OUTRIDER_SELF_INTEREST_ID = "29ca03e7-454d-446c-9941-32c96c53d95d"
+
+
+def _fetch_outrider_template(path: str) -> str:
+    """Fetch a workflow-template file from remyxai/outrider@v1 via `gh api`.
+
+    Raises ClickException if the fetch fails — the caller should treat this
+    as a hard error (missing template = we can't install the two-tier setup).
+    """
+    import base64
+    try:
+        payload = _gh_api_json([
+            "api", f"repos/{_OUTRIDER_TEMPLATE_REPO}/contents/{path}?ref={_OUTRIDER_TEMPLATE_REF}",
+        ])
+    except Exception as e:
+        raise click.ClickException(
+            f"could not fetch {path} from {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF} "
+            f"(gh api failed): {e}"
+        )
+    content_b64 = payload.get("content", "")
+    if not content_b64:
+        raise click.ClickException(
+            f"{path} on {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF} is empty."
+        )
+    return base64.b64decode(content_b64).decode()
+
+
+def _render_drafter_workflow(interest_id: str) -> str:
+    """Drafter template — fetched live from remyxai/outrider@v1 with the
+    self-test interest-id rewritten to the customer's."""
+    raw = _fetch_outrider_template(_DRAFTER_TEMPLATE_PATH)
+    if _OUTRIDER_SELF_INTEREST_ID not in raw:
+        raise click.ClickException(
+            f"drafter template on {_OUTRIDER_TEMPLATE_REPO}@{_OUTRIDER_TEMPLATE_REF} "
+            f"no longer contains the expected self-interest-id placeholder "
+            f"({_OUTRIDER_SELF_INTEREST_ID}); template format may have changed. "
+            f"CLI needs an update."
+        )
+    return raw.replace(_OUTRIDER_SELF_INTEREST_ID, interest_id)
+
+
+def _render_refiner_workflow() -> str:
+    """Refiner template — fetched live from remyxai/outrider@v1 verbatim.
+
+    The refiner has no interest-id substitution point; it dispatches
+    outrider.yml (via workflow_dispatch) which reads its own interest-id.
+    """
+    return _fetch_outrider_template(_REFINER_TEMPLATE_PATH)
+
+
 # ─── main handler ──────────────────────────────────────────────────────────
 
 def handle_outrider_setup_local(
     repo, interest_id, auto_interest, mode,
     anthropic_key, skip_confirm, dry_run, no_cron=False, no_cocoindex=False,
+    two_tier=False,
 ):
-    """Self-provision Outrider with the user's own gh token (no Remyx App)."""
+    """Self-provision Outrider with the user's own gh token (no Remyx App).
+
+    When ``two_tier=True``, installs the drafter + refiner companions
+    (`outrider-daily.yml`, `outrider-weekly-refine.yml`) alongside the
+    manual-dispatch `outrider.yml` — the recommended default for repos
+    where continuous exploration + weekly promotion is wanted. Templates
+    are fetched from ``remyxai/outrider@v1`` at install time so template
+    updates propagate to new installs without a CLI release. See
+    ``remyxai/outrider`` docs/customization.md §5 for design details.
+
+    ``--two-tier`` currently opts in — it's a strict superset of the
+    legacy single-file install, and existing installs are unaffected.
+    """
     import os
 
     if interest_id and auto_interest:
@@ -409,14 +501,30 @@ def handle_outrider_setup_local(
     click.echo(f"  - Secrets:   REMYX_API_KEY, ANTHROPIC_API_KEY")
     click.echo("  - PR auth:   enable the repo 'Actions can create PRs' setting "
                "(PRs by github-actions[bot])")
-    click.echo(f"  - Writes:    {WORKFLOW_PATH} on a branch + opens a PR")
+    if two_tier:
+        click.echo(f"  - Writes:    {WORKFLOW_PATH} (manual dispatch, no cron)")
+        click.echo(f"               {DRAFTER_WORKFLOW_PATH} (daily drafter, Haiku 4.5, publish=branch)")
+        click.echo(f"               {REFINER_WORKFLOW_PATH} (weekly refiner, picks + gap-gens + dispatches Opus)")
+        click.echo("               (three files on a branch → one PR — templates fetched live from remyxai/outrider@v1)")
+    else:
+        click.echo(f"  - Writes:    {WORKFLOW_PATH} on a branch + opens a PR")
     click.echo("")
 
     if dry_run:
-        click.echo("--- rendered workflow ---")
-        click.echo(_render_local_workflow(
-            "<interest-id>", no_cron=no_cron, no_cocoindex=no_cocoindex,
-        ))
+        if two_tier:
+            click.echo("--- rendered outrider.yml (workflow_dispatch only) ---")
+            click.echo(_render_local_workflow(
+                "<interest-id>", no_cron=True, no_cocoindex=no_cocoindex,
+            ))
+            click.echo("\n--- rendered outrider-daily.yml (drafter) ---")
+            click.echo(_render_drafter_workflow("<interest-id>"))
+            click.echo("\n--- rendered outrider-weekly-refine.yml (refiner) ---")
+            click.echo(_render_refiner_workflow())
+        else:
+            click.echo("--- rendered workflow ---")
+            click.echo(_render_local_workflow(
+                "<interest-id>", no_cron=no_cron, no_cocoindex=no_cocoindex,
+            ))
         click.secho("dry-run: no changes made.", fg="yellow")
         return
 
@@ -456,12 +564,32 @@ def handle_outrider_setup_local(
         branch_created = True
         click.echo(f"✓ Created branch {branch_name}")
 
+        # Under --two-tier: outrider.yml is manual-dispatch only (no cron —
+        # scheduled runs come from outrider-daily.yml + outrider-weekly-refine.yml).
+        # Otherwise: legacy single-file install with whatever cron the caller wants.
         workflow = _render_local_workflow(
-            resolved_interest, no_cron=no_cron, no_cocoindex=no_cocoindex,
+            resolved_interest,
+            no_cron=(no_cron or two_tier),
+            no_cocoindex=no_cocoindex,
         )
         _gh_put_file(resolved_repo, branch_name, WORKFLOW_PATH, workflow,
                      "Install Outrider (self-provisioned via remyxai CLI)")
         click.echo(f"✓ Wrote {WORKFLOW_PATH}")
+
+        if two_tier:
+            drafter_yml = _render_drafter_workflow(resolved_interest)
+            _gh_put_file(
+                resolved_repo, branch_name, DRAFTER_WORKFLOW_PATH, drafter_yml,
+                "Install Outrider two-tier drafter (self-provisioned)",
+            )
+            click.echo(f"✓ Wrote {DRAFTER_WORKFLOW_PATH}")
+
+            refiner_yml = _render_refiner_workflow()
+            _gh_put_file(
+                resolved_repo, branch_name, REFINER_WORKFLOW_PATH, refiner_yml,
+                "Install Outrider two-tier refiner (self-provisioned)",
+            )
+            click.echo(f"✓ Wrote {REFINER_WORKFLOW_PATH}")
 
         body = (
             f"Installs [Outrider](https://github.com/remyxai/outrider) "

--- a/tests/cli/test_outrider_local.py
+++ b/tests/cli/test_outrider_local.py
@@ -136,12 +136,42 @@ def test_render_declares_and_forwards_refiner_dispatch_inputs():
 _FAKE_DRAFTER_TEMPLATE = (
     "name: Outrider daily\n"
     "on:\n  schedule:\n    - cron: '0 6 * * *'\n"
-    "jobs:\n  scout:\n    steps:\n"
+    "jobs:\n  scout:\n    env:\n"
+    "      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}\n"
+    "      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n"
+    "      ANTHROPIC_MODEL: claude-haiku-4-5\n"
+    "    steps:\n"
     "      - uses: actions/checkout@v4\n"
     "      - uses: ./\n"
     "        with:\n"
     "          interest-id: '29ca03e7-454d-446c-9941-32c96c53d95d'\n"
     "          publish: branch\n"
+)
+
+# Mirrors the @v1 refiner's gap-analysis call + Opus dispatch anchors.
+_FAKE_REFINER_TEMPLATE = (
+    "name: Outrider weekly refine\n"
+    "on:\n  workflow_dispatch: {}\n"
+    "jobs:\n  refine:\n    steps:\n"
+    "      - name: Generate gap analysis\n        id: gap\n        env:\n"
+    "          BRANCH: ${{ steps.pick.outputs.picked }}\n"
+    "          REPO: ${{ github.repository }}\n"
+    "        run: |\n"
+    "          python3 - <<'PYEOF'\n"
+    "          req = urllib.request.Request(\n"
+    '              "https://api.anthropic.com/v1/messages",\n'
+    "              data=json.dumps({\n"
+    '                  "model": "claude-sonnet-4-6",\n'
+    "              }).encode(),\n"
+    "              headers={\n"
+    '                  "x-api-key": os.environ["ANTHROPIC_API_KEY"],\n'
+    "              },\n"
+    "          )\n          PYEOF\n"
+    "      - name: Dispatch Opus refinement\n        run: |\n"
+    "          gh workflow run outrider.yml \\\n"
+    "            -f provider=anthropic \\\n"
+    "            -f model=claude-opus-4-8 \\\n"
+    "            -f publish=pr\n"
 )
 
 
@@ -184,6 +214,105 @@ def test_fetch_outrider_template_calls_gh_api_without_double_prefix(monkeypatch)
     assert captured["args"][0] != "api"
     assert captured["args"][0].startswith("repos/remyxai/outrider/contents/")
     assert "ref=v1" in captured["args"][0]
+
+
+# ─── optional per-stage model overrides ─────────────────────────────────────
+
+def test_provider_inference_and_uses_zai():
+    assert outrider_local._provider_for_model("glm-5.2") == "zai"
+    assert outrider_local._provider_for_model("glm-4.6") == "zai"
+    assert outrider_local._provider_for_model("claude-opus-4-8") == "anthropic"
+    assert outrider_local.uses_zai(None, "glm-5.2", None) is True
+    assert outrider_local.uses_zai("claude-haiku-4-5", None, "claude-opus-4-8") is False
+
+
+def test_drafter_model_default_leaves_template_untouched():
+    """No --drafter-model → single-provider default preserved (Anthropic key,
+    Haiku model, no z.ai base URL)."""
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_DRAFTER_TEMPLATE):
+        wf = outrider_local._render_drafter_workflow("uuid")
+    assert "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}" in wf
+    assert "ANTHROPIC_MODEL: claude-haiku-4-5" in wf
+    assert "model-base-url" not in wf
+
+
+def test_drafter_model_glm_routes_at_zai():
+    """--drafter-model glm-5.2 swaps to Bearer auth (ZAI_API_KEY), sets the GLM
+    model + z.ai base URL, and drops ANTHROPIC_API_KEY (mutual exclusion)."""
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_DRAFTER_TEMPLATE):
+        wf = outrider_local._render_drafter_workflow("uuid", model="glm-5.2")
+    assert "ANTHROPIC_AUTH_TOKEN: ${{ secrets.ZAI_API_KEY }}" in wf
+    assert "ANTHROPIC_API_KEY:" not in wf
+    assert "ANTHROPIC_MODEL: glm-5.2" in wf
+    assert "model-base-url: https://api.z.ai/api/anthropic" in wf
+
+
+def test_drafter_model_anthropic_keeps_key_only_swaps_model():
+    """A non-default Anthropic model swaps only the model — keeps x-api-key auth,
+    no z.ai routing."""
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_DRAFTER_TEMPLATE):
+        wf = outrider_local._render_drafter_workflow("uuid", model="claude-sonnet-4-6")
+    assert "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}" in wf
+    assert "ANTHROPIC_MODEL: claude-sonnet-4-6" in wf
+    assert "model-base-url" not in wf
+
+
+def test_refiner_gap_model_glm_and_refine_dispatch():
+    """--refiner-model glm-5.2 routes the gap-analysis call at z.ai (endpoint +
+    Bearer + ZAI env); --refine-model flips the dispatch model + provider."""
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_REFINER_TEMPLATE):
+        wf = outrider_local._render_refiner_workflow(
+            gap_model="glm-5.2", refine_model="glm-4.6",
+        )
+    # gap-analysis routed at z.ai
+    assert "https://api.z.ai/api/anthropic/v1/messages" in wf
+    assert '"model": "glm-5.2"' in wf
+    assert "Bearer {os.environ['ZAI_API_KEY']}" in wf
+    assert "ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}" in wf
+    # dispatched refine run flipped to GLM/zai
+    assert "-f model=glm-4.6" in wf
+    assert "-f provider=zai" in wf
+
+
+def test_refiner_default_leaves_template_untouched():
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_REFINER_TEMPLATE):
+        wf = outrider_local._render_refiner_workflow()
+    assert "https://api.anthropic.com/v1/messages" in wf
+    assert '"model": "claude-sonnet-4-6"' in wf
+    assert "-f model=claude-opus-4-8" in wf and "-f provider=anthropic" in wf
+
+
+def test_refine_model_anthropic_keeps_provider_anthropic():
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_REFINER_TEMPLATE):
+        wf = outrider_local._render_refiner_workflow(refine_model="claude-opus-4-8")
+    assert "-f model=claude-opus-4-8" in wf and "-f provider=anthropic" in wf
+
+
+def test_model_override_anchor_guard_fails_loud():
+    """A template that lost the ANTHROPIC_MODEL anchor must raise, not silently
+    skip the override."""
+    broken = _FAKE_DRAFTER_TEMPLATE.replace("ANTHROPIC_MODEL: claude-haiku-4-5\n", "")
+    with patch.object(outrider_local, "_fetch_outrider_template", return_value=broken):
+        with pytest.raises(click.ClickException, match="no longer contains the expected anchor"):
+            outrider_local._render_drafter_workflow("uuid", model="glm-5.2")
+
+
+def test_model_flags_require_two_tier(monkeypatch):
+    """--drafter-model without --two-tier is a usage error."""
+    monkeypatch.setenv("REMYXAI_API_KEY", "rk")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ak")
+    with pytest.raises(click.UsageError, match="require --two-tier"):
+        outrider_local.handle_outrider_setup_local(
+            repo="o/r", interest_id="uuid", auto_interest=False, mode="review",
+            anthropic_key=None, skip_confirm=True, dry_run=True,
+            two_tier=False, drafter_model="glm-5.2",
+        )
 
 
 # ─── gh secret stdin invariant ───────────────────────────────────────────────

--- a/tests/cli/test_outrider_local.py
+++ b/tests/cli/test_outrider_local.py
@@ -117,6 +117,75 @@ def test_render_forwards_workflow_dispatch_inputs_to_action():
         )
 
 
+def test_render_declares_and_forwards_refiner_dispatch_inputs():
+    """The runner must declare + forward every input the refiner
+    (outrider-weekly-refine.yml) dispatches — mode, publish, start-from-ref,
+    lead-content, staged-synthesis — or GitHub rejects the dispatch as an
+    unknown workflow_dispatch key and no refinement PR opens."""
+    wf = outrider_local._render_local_workflow("uuid")
+    for name in ("mode", "publish", "start-from-ref", "lead-content", "staged-synthesis"):
+        assert f"      {name}:" in wf, f"missing input declaration: {name}"
+        assert f"{name}: ${{{{ inputs.{name} }}}}" in wf, f"missing forwarding for {name}"
+    # Defaults match the action's own so scheduled/manual runs are unchanged.
+    assert "default: 'recommend'" in wf   # mode
+    assert "default: 'pr'" in wf          # publish
+
+
+# ─── two-tier template rendering (fetched from remyxai/outrider@v1) ──────────
+
+_FAKE_DRAFTER_TEMPLATE = (
+    "name: Outrider daily\n"
+    "on:\n  schedule:\n    - cron: '0 6 * * *'\n"
+    "jobs:\n  scout:\n    steps:\n"
+    "      - uses: actions/checkout@v4\n"
+    "      - uses: ./\n"
+    "        with:\n"
+    "          interest-id: '29ca03e7-454d-446c-9941-32c96c53d95d'\n"
+    "          publish: branch\n"
+)
+
+
+def test_render_drafter_rewrites_local_action_and_interest_id():
+    """The drafter fetched from @v1 uses `uses: ./` (resolves only inside the
+    outrider repo) and a self-test interest-id. Both must be rewritten so the
+    installed drafter targets the published action + customer's interest."""
+    with patch.object(outrider_local, "_fetch_outrider_template",
+                      return_value=_FAKE_DRAFTER_TEMPLATE):
+        rendered = outrider_local._render_drafter_workflow("cust-uuid")
+    assert "uses: ./" not in rendered
+    assert "uses: remyxai/outrider@v1" in rendered
+    assert "interest-id: 'cust-uuid'" in rendered
+    assert outrider_local._OUTRIDER_SELF_INTEREST_ID not in rendered
+
+
+def test_render_drafter_guards_missing_local_action_ref():
+    """If the template stops referencing the action via `uses: ./`, fail loud
+    rather than silently shipping an un-rewritten drafter."""
+    broken = _FAKE_DRAFTER_TEMPLATE.replace("uses: ./", "uses: remyxai/outrider@v1")
+    with patch.object(outrider_local, "_fetch_outrider_template", return_value=broken):
+        with pytest.raises(click.ClickException, match="no longer references the action"):
+            outrider_local._render_drafter_workflow("cust-uuid")
+
+
+def test_fetch_outrider_template_calls_gh_api_without_double_prefix(monkeypatch):
+    """Regression: _fetch_outrider_template must pass the contents path directly
+    to _gh_api_json (which already prepends `gh api`), not a leading 'api' arg
+    that would produce `gh api api repos/...`."""
+    import base64
+    captured = {}
+
+    def fake_gh_api_json(args):
+        captured["args"] = args
+        return {"content": base64.b64encode(b"hello").decode()}
+
+    monkeypatch.setattr(outrider_local, "_gh_api_json", fake_gh_api_json)
+    out = outrider_local._fetch_outrider_template(".github/workflows/outrider-daily.yml")
+    assert out == "hello"
+    assert captured["args"][0] != "api"
+    assert captured["args"][0].startswith("repos/remyxai/outrider/contents/")
+    assert "ref=v1" in captured["args"][0]
+
+
 # ─── gh secret stdin invariant ───────────────────────────────────────────────
 
 def test_gh_set_secret_value_via_stdin(monkeypatch):


### PR DESCRIPTION
## Summary

Adds an opt-in `--two-tier` flag to `remyxai outrider setup-local` that installs the drafter/refiner companion workflows matching the pattern in `remyxai/outrider` main. Templates are fetched from `remyxai/outrider@v1` at install time rather than embedded inline in the CLI.

## Design choices

**Live template fetching vs inline embedding.** Templates are fetched from `remyxai/outrider@v1` at install time via `gh api`. Treating the outrider repo as the canonical source of truth for the workflow shape means template refinements propagate to new customer installs automatically without requiring a CLI release.

**Opt-in, not default.** `--two-tier` currently opts in; the default install produces the legacy single-file `outrider.yml`. Non-breaking — existing customer workflows and bulk-repos scripts continue to produce identical output. A follow-up CLI release can flip the default once the templates on `remyxai/outrider@v1` have accumulated a few production weeks.

## What `--two-tier` writes

Three files on a single install branch, all in one PR:

- `.github/workflows/outrider.yml` — workflow_dispatch only, no cron (manual + refiner target)
- `.github/workflows/outrider-daily.yml` — drafter role, daily cron, Anthropic Haiku 4.5, publish=branch
- `.github/workflows/outrider-weekly-refine.yml` — refiner orchestrator, weekly cron

Dry-run mode renders all three when `--two-tier` is set.

## Tests

- 15 existing tests still pass — the legacy single-file path is unchanged
- New fetch-based code path: should have a follow-up test that mocks `gh api` for both templates and asserts substitution + write ordering. Not blocking for this ship since the fetch path is exercised only when `--two-tier` is set (opt-in).

## Follow-ups

- CLI test coverage for the two-tier path (mock gh api, assert branch + files + PR shape)
- Default flip in a subsequent CLI release
- Docs update in remyxai-cli's docs/commands.md to mention `--two-tier`