### PR TITLE
outrider trigger: --base-url + --publish; init template: base-url input

### DIFF
--- a/remyxai/cli/commands.py
+++ b/remyxai/cli/commands.py
@@ -896,7 +896,27 @@ def outrider_setup_local(
                   "which sets ANTHROPIC_MODEL in the action's env. "
                   "Empty = provider picks its default."
               ))
-def outrider_trigger(repo, search_method, pin_arxiv, interest_id, ref, claude_timeout, provider, model):
+@click.option("--base-url", "base_url", default=None,
+              help=(
+                  "Anthropic-compatible endpoint URL to route the coding "
+                  "agent at (self-hosted model behind a litellm proxy, "
+                  "vLLM Anthropic shim, on-prem gateway, Cloudflare "
+                  "Access). Overrides the per-provider default. Requires "
+                  "the target workflow to declare a `base-url` "
+                  "workflow_dispatch input; older templates need "
+                  "`remyxai outrider init` re-run to pick this up."
+              ))
+@click.option("--publish", "publish", default=None,
+              type=click.Choice(["pr", "branch"]),
+              help=(
+                  "'pr' (default) opens a draft PR / Issue on the target "
+                  "repo. 'branch' produces the drafter branch without "
+                  "opening a PR — useful for dogfooding a run and "
+                  "reviewing the output before deciding what to publish. "
+                  "Requires the target workflow to declare a `publish` "
+                  "input (all CLI-generated templates do)."
+              ))
+def outrider_trigger(repo, search_method, pin_arxiv, interest_id, ref, claude_timeout, provider, model, base_url, publish):
     """
     Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
 
@@ -945,6 +965,8 @@ def outrider_trigger(repo, search_method, pin_arxiv, interest_id, ref, claude_ti
         claude_timeout=claude_timeout,
         provider=provider,
         model=model,
+        base_url=base_url,
+        publish=publish,
     )
 
 

--- a/remyxai/cli/outrider_actions.py
+++ b/remyxai/cli/outrider_actions.py
@@ -566,7 +566,7 @@ def _gh_latest_run_url(repo, sleep=time.sleep):
 
 def handle_outrider_trigger(
     repo, search_method, pin_arxiv, interest_id, ref, claude_timeout=None,
-    provider=None, model=None,
+    provider=None, model=None, base_url=None, publish=None,
 ):
     """Dispatch a one-shot Outrider run on a repo via workflow_dispatch.
 
@@ -636,6 +636,13 @@ def handle_outrider_trigger(
         # hand-rolled workflows may need updating.
         "provider": provider or "",
         "model": model or "",
+        # `base-url` routes the coding agent at a self-hosted or on-prem
+        # Anthropic-compatible endpoint (litellm proxy, vLLM shim,
+        # Cloudflare Access, etc). Overrides the per-provider default.
+        # `publish=branch` produces the drafter branch without opening a
+        # PR — dogfood / review-before-publish path.
+        "base-url": base_url or "",
+        "publish": publish or "",
     }
 
     click.echo(f"Dispatching Outrider on {resolved_repo} (ref={branch})…")
@@ -643,6 +650,10 @@ def handle_outrider_trigger(
         click.echo(f"  provider:       {provider}")
     if model:
         click.echo(f"  model:          {model}")
+    if base_url:
+        click.echo(f"  base-url:       {base_url}")
+    if publish:
+        click.echo(f"  publish:        {publish}")
     if search_method:
         click.echo(f"  search-method:  {search_method!r}")
     if pin_arxiv:

--- a/remyxai/cli/outrider_local.py
+++ b/remyxai/cli/outrider_local.py
@@ -357,6 +357,10 @@ on:
         description: 'Specific model name (e.g. claude-opus-4-8, glm-5.2, kimi-k3). Empty = provider default.'
         required: false
         default: ''
+      base-url:
+        description: 'Optional Anthropic-compatible endpoint (self-hosted model, litellm proxy, vLLM Anthropic shim, on-prem gateway). Overrides the per-provider default when set. Empty = provider default.'
+        required: false
+        default: ''
       search-method:
         description: 'Optional free-text method query. Runs an engine search and implements the top hit.'
         required: false
@@ -424,6 +428,7 @@ jobs:
           # extend the implementation timeout, etc.
           provider: ${{{{ inputs.provider }}}}
           model: ${{{{ inputs.model }}}}
+          model-base-url: ${{{{ inputs.base-url }}}}
           search-method: ${{{{ inputs.search-method }}}}
           pin-arxiv: ${{{{ inputs.pin-arxiv }}}}
           claude-timeout: ${{{{ inputs.claude-timeout }}}}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="remyxai",
-    version="0.4.7",
+    version="0.4.8",
     packages=find_packages(include=["remyxai", "remyxai.*"]),
     install_requires=[
         "click",

--- a/tests/cli/test_outrider_local.py
+++ b/tests/cli/test_outrider_local.py
@@ -55,17 +55,16 @@ def test_render_declares_provider_workflow_input_with_all_backends():
     assert "default: 'anthropic'" in wf
 
 
-def test_render_forwards_provider_and_model_to_action():
-    """Both `provider` and `model` workflow_dispatch inputs are threaded
-    into the action's `with:` block so per-dispatch overrides propagate
-    all the way through — the action's `provider` input drives base-URL +
-    auth wiring; `model` sets ANTHROPIC_MODEL for cost telemetry accuracy."""
+def test_render_forwards_provider_model_and_base_url_to_action():
+    """`provider`, `model`, and `base-url` workflow_dispatch inputs are
+    threaded into the action's `with:` block so per-dispatch overrides
+    propagate all the way through — the action's `provider` picks default
+    base-URL + auth wiring, `model` sets ANTHROPIC_MODEL, and an explicit
+    `base-url` overrides the provider default (self-hosted / on-prem)."""
     wf = outrider_local._render_local_workflow("uuid")
     assert "provider: ${{ inputs.provider }}" in wf
     assert "model: ${{ inputs.model }}" in wf
-    # model-base-url is no longer set from the workflow — the action's
-    # `provider` input picks the base URL from its internal map.
-    assert "model-base-url:" not in wf
+    assert "model-base-url: ${{ inputs.base-url }}" in wf
 
 
 def test_render_backend_moonshot_selects_moonshot_default_and_timeout():

--- a/tests/cli/test_outrider_trigger.py
+++ b/tests/cli/test_outrider_trigger.py
@@ -550,3 +550,135 @@ def test_cli_model_combines_with_provider(monkeypatch):
     assert captured["inputs"]["model"] == "glm-4.6"
     assert captured["inputs"]["claude-timeout"] == "1500"
     assert "model:          glm-4.6" in result.output
+
+
+# ─── --base-url forwarding ────────────────────────────────────────────────
+
+
+def test_trigger_forwards_base_url_when_set(monkeypatch, capsys):
+    """`--base-url` flows to workflow_dispatch as the `base-url` input —
+    the self-hosted / on-prem coding-agent endpoint override."""
+    captured = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        captured["inputs"] = inputs
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda repo, sleep=None: None)
+
+    outrider_actions.handle_outrider_trigger(
+        repo="owner/name", search_method=None, pin_arxiv="2607.24223",
+        interest_id=None, ref=None,
+        base_url="https://litellm.internal.acme/anthropic",
+    )
+    assert captured["inputs"]["base-url"] == "https://litellm.internal.acme/anthropic"
+    assert "base-url:       https://litellm.internal.acme/anthropic" in capsys.readouterr().out
+
+
+def test_trigger_omits_base_url_when_unset(monkeypatch):
+    """No flag → empty string → workflow's per-provider default applies."""
+    captured = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        captured["inputs"] = inputs
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda repo, sleep=None: None)
+
+    outrider_actions.handle_outrider_trigger(
+        repo="owner/name", search_method="X", pin_arxiv=None,
+        interest_id=None, ref=None,
+    )
+    assert captured["inputs"]["base-url"] == ""
+
+
+# ─── --publish forwarding ─────────────────────────────────────────────────
+
+
+def test_trigger_forwards_publish_branch(monkeypatch, capsys):
+    """`--publish branch` produces the drafter branch without opening a PR
+    — the dogfood / review-before-publish path."""
+    captured = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        captured["inputs"] = inputs
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda repo, sleep=None: None)
+
+    outrider_actions.handle_outrider_trigger(
+        repo="owner/name", search_method=None, pin_arxiv="2607.24223",
+        interest_id=None, ref=None, publish="branch",
+    )
+    assert captured["inputs"]["publish"] == "branch"
+    assert "publish:        branch" in capsys.readouterr().out
+
+
+def test_cli_base_url_and_publish_reach_dispatch(monkeypatch):
+    """End-to-end through click: --base-url + --publish both land in the
+    dispatched inputs, alongside --provider / --pin-arxiv."""
+    captured = {}
+
+    def fake_dispatch(repo, branch, inputs):
+        captured["inputs"] = inputs
+        return (True, "")
+
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+    monkeypatch.setattr(outrider_actions, "_gh_dispatch_outrider", fake_dispatch)
+    monkeypatch.setattr(outrider_actions, "_gh_latest_run_url",
+                        lambda r, sleep=None: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "outrider", "trigger",
+        "--repo", "owner/name",
+        "--pin-arxiv", "2607.24223",
+        "--base-url", "https://litellm.internal.acme/anthropic",
+        "--publish", "branch",
+        "--provider", "zai",
+        "--model", "glm-5.2",
+    ])
+    assert result.exit_code == 0, result.output
+    assert captured["inputs"]["base-url"] == "https://litellm.internal.acme/anthropic"
+    assert captured["inputs"]["publish"] == "branch"
+    assert captured["inputs"]["provider"] == "zai"
+    assert captured["inputs"]["pin-arxiv"] == "2607.24223"
+
+
+def test_cli_publish_rejects_unknown_value(monkeypatch):
+    """`--publish foo` fails at click's argument-parsing layer — before
+    any dispatch — so we never ship an invalid workflow input on the wire."""
+    monkeypatch.setattr(outrider_actions, "_outrider_workflow_exists",
+                        lambda repo: True)
+    monkeypatch.setattr(outrider_actions, "_gh_default_branch",
+                        lambda repo: "main")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "outrider", "trigger",
+        "--repo", "owner/name",
+        "--publish", "release",
+    ])
+    assert result.exit_code != 0
+    assert "publish" in result.output.lower()


### PR DESCRIPTION
## Summary
- `remyxai outrider trigger --base-url URL` — route the coding agent at any Anthropic-compatible endpoint (self-hosted litellm proxy, vLLM Anthropic shim, on-prem gateway, Cloudflare Access). Overrides the per-provider default.
- `remyxai outrider trigger --publish {pr,branch}` — `branch` produces the drafter branch without opening a PR. Dogfood / review-before-publish path — previously only reachable via `gh workflow run -f publish=branch`.
- `outrider setup-local` template gains a matching `base-url` workflow_dispatch input, wired to the composite action's `model-base-url`. New customer installs pick it up; existing installs need a template refresh.

Ships alongside `remyxai/outrider@v1.7.45`, which adds the same input on this repo's internal runner.

## Test plan
- [x] `pytest tests/cli/ -q` — 135 passed
- [x] `remyxai outrider trigger --help` surfaces `--base-url` and `--publish`
- [x] Click rejects unknown `--publish` values before dispatch
- [ ] Manual: dispatch a customer template regenerated after this ships and confirm `base-url` reaches the action